### PR TITLE
Update offensive_words.json

### DIFF
--- a/public/js/offensive_words.json
+++ b/public/js/offensive_words.json
@@ -3109,6 +3109,7 @@
     "who are",
     "potion o gold",
     "proxy",
-    "price"
+    "price",
+    "again dont"
 ]
 }

--- a/public/js/offensive_words.json
+++ b/public/js/offensive_words.json
@@ -3104,6 +3104,11 @@
     "therapists",
     "jazz",
     "shoes",
-    "documentary"
+    "documentary",
+    "per se",
+    "who are",
+    "potion o gold",
+    "proxy",
+    "price"
 ]
 }


### PR DESCRIPTION
Added to the whitelisted words:
- "per se" (meaning by itself/themselves)
- "who are" (the filter detected "hoare")
- "potion o gold" (the filter detected "nog")
- "proxy" (the filter detected "oxy", which is a kind of drug)
- "price" (the filter detected "pric") Credits to @xkzla on the Talkomatic discord for reporting these!