### PR TITLE
Fix carriage return filter bypass

### DIFF
--- a/server.js
+++ b/server.js
@@ -1471,6 +1471,7 @@ io.on('connection', (socket) => {
           ));
           return;
       }
+      userMessage = userMessage.replaceAll('\r', ''); // To prevent the carriage return filter bypass
       userMessageBuffers.set(userId, userMessage);
       if (CONFIG.FEATURES.ENABLE_WORD_FILTER) {
         const filterResult = wordFilter.checkText(userMessage);


### PR DESCRIPTION
For a reason that I'm still not sure about, carriage returns make the app behave pretty weirdly.
Since they are here unneeded due to new lines without carriage returns working just fine, this line removes the filter bypass using these carriage returns, since except for the bug, they're useless.