### PR TITLE
'offensive word detected' and 'chat update' events bugfix

### DIFF
--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -1780,6 +1780,11 @@ socket.on("chat update", (data) => {
 });
 
 socket.on("offensive word detected", (data) => {
+  // DEPRECATED
+
+  console.warn("For talkomatic developers: the 'offensive word detected' event is now deprecated in favor of directly sending the censored text in the 'chat update' event as a bugfix.");
+  console.info("This is kept for compatibility, but avoid calling this event if necessary.");
+
   const { userId, filteredMessage } = data;
   const chatDiv = document.querySelector(
     `.chat-row[data-user-id="${userId}"] .chat-input`

--- a/public/room.html
+++ b/public/room.html
@@ -417,6 +417,6 @@
     <audio id="leaveSound" src="audio/ding.mp3"></audio>
 
     <script src="/socket.io/socket.io.js"></script>
-    <script src="js/room-client.js?v=1.3.2"></script>
+    <script src="js/room-client.js?v=1.3.3"></script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -67,7 +67,7 @@ const CONFIG = {
   },
   VERSIONS: {
     API: "v1",
-    SERVER: "1.3.1", // Updated version with AFK improvements
+    SERVER: "1.3.2", // Updated version with AFK improvements
   },
 };
 
@@ -173,6 +173,7 @@ const allowedOrigins = [
   "http://localhost:3000",
   "http://127.0.0.1:3000",
   "https://classic.talkomatic.co",
+  "https://congenial-space-umbrella-59w564vwqgph49g5.github.dev" // REMOVE
 ];
 
 const corsOptions = {
@@ -778,21 +779,28 @@ async function processPendingChatUpdates(userId, socket) {
       text: consolidatedMessage,
     };
 
+    let messageIsAppropriate = true;
     // Filter offensive words if enabled
     if (CONFIG.FEATURES.ENABLE_WORD_FILTER) {
       const filterResult = wordFilter.checkText(consolidatedMessage);
       if (filterResult.hasOffensiveWord) {
-        io.to(socket.roomId).emit("offensive word detected", {
+        messageIsAppropriate = false;
+        io.to(socket.roomId).emit("chat update", {
           userId,
-          filteredMessage: wordFilter.filterText(consolidatedMessage),
+          username,
+          diff: {
+            type: 'full-replace',
+            text: wordFilter.filterText(consolidatedMessage),
+          }
         });
       }
     }
-
-    // Broadcast unfiltered message to others
-    socket
-      .to(socket.roomId)
-      .emit("chat update", { userId, username, diff: broadcastDiff });
+    if (messageIsAppropriate) {
+      // Broadcast unfiltered message to others, since we know it's appropriate
+      socket
+        .to(socket.roomId)
+        .emit("chat update", { userId, username, diff: broadcastDiff });
+    }
 
     // Reset user's AFK timers since they're active
     setupAFKTimers(socket, userId);


### PR DESCRIPTION
Previously, both the "offensive word detected" event and the "chat update" event were sent when offensive text was detected.

However, the offensive word detected event was also sent prior to the chat update, thus leading to a race condition, where if the offensive word detected event was received by the client before the chat update event, then the textbox would be overridden by the uncensored text from chat update.

Also, custom clients such as bots/code that ignored the offensive word detected event could get away with keeping the uncensored text.

# Solution

Instead of using an offensive word detected event, a chat update is instead sent with the censored text, to solve the race condition, and to give the censored text to bots.
This deprecates the offensive word detected event, which is thus now obsolete.