### PR TITLE
About GitHub link bugfix, allow iframes, filter update

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -407,7 +407,7 @@
             <p>Talkomatic Classic is an open-source project with no ads or tracking. We rely on community support to keep the servers running and continue development.</p>
             <div class="cta-buttons">
                 <a href="sponsors.html" class="cta-button" aria-label="Become a sponsor">Become a Sponsor</a>
-                <a href="https://github.com/mohdyahyaymahmodi/talkomatic-classic" class="cta-button secondary" aria-label="View project on GitHub">View on GitHub</a>
+                <a href="https://github.com/mohdyahyamahmodi/talkomatic-classic" class="cta-button secondary" aria-label="View project on GitHub">View on GitHub</a>
             </div>
         </section>
         

--- a/public/js/offensive_words.json
+++ b/public/js/offensive_words.json
@@ -2992,6 +2992,7 @@
     "district",
     "document",
     "documentary",
+    "dont eat",
     "embassy",
     "encompass",
     "enthusiasm",

--- a/public/js/offensive_words.json
+++ b/public/js/offensive_words.json
@@ -3092,6 +3092,7 @@
     "raster",
     "reassurance",
     "reassure",
+    "scooter",
     "seaweed",
     "session",
     "shoes",

--- a/server.js
+++ b/server.js
@@ -387,6 +387,7 @@ app.use(
         ],
         objectSrc: ["'none'"],
         mediaSrc: ["'self'"],
+        frameAncestors: ["'self'", "*"], // allow others to iframe our site
         frameSrc: ["'none'"],
         styleSrcElem: [
           "'self'",


### PR DESCRIPTION
Addresses issue #44 by fixing the bug in the misspelled link in about.html, and by allowing iframes by modifying the CSP to put a new rule for frame-ancestors allowing everything (*).

It also adds the whitelisted word "scooter" (falsely flagged due to cooter) to the filter (reported by @dammer9 on the Discord server).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the GitHub link on the About page to ensure the link directs to the correct profile.

* **New Features**
  * Added "dont eat" and "scooter" to the whitelist of acceptable words.

* **Chores**
  * Updated security settings to allow the site to be embedded in iframes from any origin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->