### PR TITLE
Small theme stylesheet bugfix

### DIFF
--- a/public/js/offensive_words.json
+++ b/public/js/offensive_words.json
@@ -402,6 +402,7 @@
     "brown shower",
     "brown showers",
     "brunette action",
+    "bsod",
     "btch",
     "buceta",
     "buddhahead",

--- a/public/stylesheets/lobby.css
+++ b/public/stylesheets/lobby.css
@@ -284,7 +284,7 @@ html {
 }
 
 .external-links a:visited {
-  color: var(--visited-external-links-background-color);
+  background-color: var(--visited-external-links-background-color);
 }
 
 /* if there’s an odd number of links, the last one spans both columns */

--- a/public/stylesheets/lobby.css
+++ b/public/stylesheets/lobby.css
@@ -18,7 +18,7 @@
   --left-panel-background-color: #616161;
   --external-links-background-color: #444444;
   --hover-external-links-background-color: #1b1b1b;
-  --visited-external-links-background-color: white;
+  --visited-external-links-background-color: #1b1b1b;
   --known-as-section-background-color: #fdf5e6;
   --logform-background-color: white;
   --logform-button-background-color: black;


### PR DESCRIPTION
Incorrectly applied color instead of background color in visited external links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the appearance of visited external links by changing their background color instead of their text color.
* **Chores**
  * Added a new term to the offensive words filter list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->