### PR TITLE
fix: improve mobile room layout

### DIFF
--- a/public/stylesheets/room.css
+++ b/public/stylesheets/room.css
@@ -55,7 +55,9 @@ body,
 html {
   margin: 0;
   padding: 0;
+  /* Use dynamic viewport units to prevent white gaps when mobile keyboards appear */
   height: 100vh;
+  height: 100dvh;
   font-family: talkoSS, Arial, sans-serif;
   background-color: #f0f0f0;
   font-size: 16px;
@@ -65,7 +67,9 @@ html {
 .page-container {
   display: flex;
   flex-direction: column;
+  /* Match the visible viewport height on mobile */
   height: 100vh;
+  height: 100dvh;
 }
 
 /* =============================================================================


### PR DESCRIPTION
## Summary
- use dynamic viewport height units in room layout to prevent white gaps when mobile keyboards appear

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68959330bf888321b36b36da2e1199d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile display by updating height properties to use dynamic viewport units, ensuring better handling of mobile keyboards and preventing unwanted white gaps.
  * Added comments for clarity on height settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->