### PR TITLE
Fix ghost users on restart when LOAD_ROOMS_ON_STARTUP enabled

### DIFF
--- a/server.js
+++ b/server.js
@@ -1578,6 +1578,9 @@ async function loadRooms() {
             } else {
               item[1].bannedUserIds = new Set();
             }
+            item[1].users = [];
+            item[1].lastActiveTime = Date.now();
+            startRoomDeletionTimer(item[0]);
           }
           return item;
         })


### PR DESCRIPTION
When the server restarts with `LOAD_ROOMS_ON_STARTUP` enabled, all room data, including users, is loaded from `rooms.json`. These users aren't connected to the websocket, and are never removed, which makes them stuck as a ghost forever.

This fix makes sure that:
1. The `users` arrays are cleared for loaded rooms
2. The room deletion timer is started for loaded rooms

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rooms are now properly initialized for automatic cleanup on startup, ensuring pre-existing rooms are eligible for deletion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->