### PR TITLE
Clear stale users on load and misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 rooms.json
 users.json
+repo-tree.html
 
 # Dependency directories
 node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
     Security Policy (CSP) purposes to allow only authorized scripts to run.
     Last updated: 2024
 -->
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <!-- Head Section: Metadata and External Resources -->
   <head>
@@ -238,7 +238,9 @@
         border: 1px solid #444;
         border-radius: 12px;
         padding: 20px;
-        transition: transform 0.2s ease, border-color 0.2s ease;
+        transition:
+          transform 0.2s ease,
+          border-color 0.2s ease;
       }
 
       .stats-card:hover {
@@ -512,6 +514,10 @@
           gap: 10px;
           text-align: center;
         }
+      }
+
+      #noRoomsMessage {
+        color: white;
       }
     </style>
     <script src="https://unpkg.com/idb@8.0.3/build/umd.js"></script>

--- a/public/js/lobby-client.js
+++ b/public/js/lobby-client.js
@@ -196,7 +196,7 @@ class StatsModal {
       version: document.getElementById("modalStatsVersion"),
       uptime: document.getElementById("modalStatsUptime"),
       utilizationPercentage: document.getElementById(
-        "modalUtilizationPercentage"
+        "modalUtilizationPercentage",
       ),
       utilizationFill: document.getElementById("modalUtilizationFill"),
       public: document.getElementById("modalStatsPublic"),
@@ -283,7 +283,7 @@ class StatsModal {
 
       if (!healthResponse.ok) {
         throw new Error(
-          `HTTP ${healthResponse.status}: ${healthResponse.statusText}`
+          `HTTP ${healthResponse.status}: ${healthResponse.statusText}`,
         );
       }
 
@@ -332,7 +332,7 @@ class StatsModal {
     this.elements.utilizationPercentage.textContent = `${utilization}%`;
     this.elements.utilizationFill.style.width = `${Math.min(
       utilization,
-      100
+      100,
     )}%`;
 
     // Update room types
@@ -346,7 +346,7 @@ class StatsModal {
     // Update last updated time
     this.lastUpdateTime = new Date();
     this.elements.lastUpdated.textContent = `Last updated ${this.formatTime(
-      this.lastUpdateTime
+      this.lastUpdateTime,
     )}`;
   }
 
@@ -427,10 +427,10 @@ const roomListContainer = document.querySelector(".roomList");
 const dynamicRoomList = document.getElementById("dynamicRoomList");
 const usernameInput = logForm.querySelector('input[placeholder="Your Name"]');
 const locationInput = logForm.querySelector(
-  'input[placeholder="Location (optional)"]'
+  'input[placeholder="Location (optional)"]',
 );
 const roomNameInput = createRoomForm.querySelector(
-  'input[placeholder="Room Name"]'
+  'input[placeholder="Room Name"]',
 );
 const goChatButton = createRoomForm.querySelector(".go-chat-button");
 const signInButton = logForm.querySelector('button[type="submit"]');
@@ -488,7 +488,7 @@ socket.on("connect_error", (error) => {
   if (connectionRetryCount < MAX_RETRIES) {
     connectionRetryCount++;
     console.log(
-      `Retrying connection (${connectionRetryCount}/${MAX_RETRIES})...`
+      `Retrying connection (${connectionRetryCount}/${MAX_RETRIES})...`,
     );
 
     // If we get a connection error, try to reconnect with a clean session
@@ -502,7 +502,7 @@ socket.on("connect_error", (error) => {
   } else {
     window.showErrorModal(
       "Unable to connect to the server. Please refresh the page and try again.",
-      "SERVER_ERROR"
+      "SERVER_ERROR",
     );
   }
 });
@@ -585,17 +585,17 @@ goChatButton.addEventListener("click", () => {
   if (!socket.connected) {
     window.showErrorModal(
       "Not connected to server. Please wait for connection or refresh the page.",
-      "SERVER_ERROR"
+      "SERVER_ERROR",
     );
     return;
   }
 
   const roomName = roomNameInput.value.trim().slice(0, MAX_ROOM_NAME_LENGTH);
   const roomType = document.querySelector(
-    'input[name="roomType"]:checked'
+    'input[name="roomType"]:checked',
   )?.value;
   const roomLayout = document.querySelector(
-    'input[name="roomLayout"]:checked'
+    'input[name="roomLayout"]:checked',
   )?.value;
   const accessCode = accessCodeInput.querySelector("input").value;
 
@@ -603,7 +603,7 @@ goChatButton.addEventListener("click", () => {
     if (roomType === "semi-private") {
       if (!accessCode || accessCode.length !== 6 || !/^\d+$/.test(accessCode)) {
         window.showErrorModal(
-          "Please enter a valid 6-digit access code for the semi-private room."
+          "Please enter a valid 6-digit access code for the semi-private room.",
         );
         return;
       }
@@ -628,7 +628,7 @@ dynamicRoomList.addEventListener("click", (e) => {
     if (!socket.connected) {
       window.showErrorModal(
         "Not connected to server. Please wait for connection or refresh the page.",
-        "SERVER_ERROR"
+        "SERVER_ERROR",
       );
       return;
     }
@@ -666,7 +666,7 @@ function promptAccessCode(roomId) {
         lastUsedAccessCode = accessCode;
         joinRoom(roomId, accessCode);
       }
-    }
+    },
   );
 }
 
@@ -674,7 +674,7 @@ function joinRoom(roomId, accessCode = null) {
   if (!socket.connected) {
     window.showErrorModal(
       "Not connected to server. Please wait for connection or refresh the page.",
-      "SERVER_ERROR"
+      "SERVER_ERROR",
     );
     return;
   }
@@ -781,7 +781,7 @@ socket.on("error", (error) => {
   window.showErrorModal(
     (error.error.replaceDefaultText ? "" : `An error occurred: `) +
       error.error.message,
-    error.error.code
+    error.error.code,
   );
 });
 
@@ -892,11 +892,10 @@ function showRoomList() {
 }
 
 function initLobby() {
+  document.querySelector('input[name="roomType"][value="public"]').checked =
+    true;
   document.querySelector(
-    'input[name="roomType"][value="public"]'
-  ).checked = true;
-  document.querySelector(
-    'input[name="roomLayout"][value="horizontal"]'
+    'input[name="roomLayout"][value="horizontal"]',
   ).checked = true;
 
   // Initialize stats modal

--- a/public/js/lobby.js
+++ b/public/js/lobby.js
@@ -14,47 +14,47 @@
 // ============================================================================
 
 // DOM Element References
-const leftPanel = document.getElementById('leftPanel');
-const toggleButton = document.getElementById('toggleButton');
-const hideMenuButton = document.getElementById('hideMenuButton');
+const leftPanel = document.getElementById("leftPanel");
+const toggleButton = document.getElementById("toggleButton");
+const hideMenuButton = document.getElementById("hideMenuButton");
 
 // Modal functionality
-const roomInfoModal = document.getElementById('roomInfoModal');
-const learnMoreBtn = document.querySelector('.learn-more');
-const closeRoomInfoBtn = document.querySelector('.close-modal');
+const roomInfoModal = document.getElementById("roomInfoModal");
+const learnMoreBtn = document.querySelector(".learn-more");
+const closeRoomInfoBtn = document.querySelector(".close-modal");
 
 /**
  * Toggles the left panel open/closed state
  */
 function toggleLeftPanel() {
-    leftPanel.classList.toggle('open');
-    toggleButton.style.opacity = leftPanel.classList.contains('open') ? '0' : '1';
+  leftPanel.classList.toggle("open");
+  toggleButton.style.opacity = leftPanel.classList.contains("open") ? "0" : "1";
 }
 
 /**
  * Hides the left panel
  */
 function hideLeftPanel() {
-    leftPanel.classList.remove('open');
-    setTimeout(() => {
-        toggleButton.style.opacity = '1';
-    }, 300);
+  leftPanel.classList.remove("open");
+  setTimeout(() => {
+    toggleButton.style.opacity = "1";
+  }, 300);
 }
 
 /**
  * Handles window resize events
  */
 function handleResize() {
-    if (window.innerWidth > 992) {
-        leftPanel.classList.remove('open');
-        toggleButton.style.opacity = '0';
-        hideMenuButton.style.display = 'none';
-    } else {
-        if (!leftPanel.classList.contains('open')) {
-            toggleButton.style.opacity = '1';
-        }
-        hideMenuButton.style.display = 'block';
+  if (window.innerWidth > 992) {
+    leftPanel.classList.remove("open");
+    toggleButton.style.opacity = "0";
+    hideMenuButton.style.display = "none";
+  } else {
+    if (!leftPanel.classList.contains("open")) {
+      toggleButton.style.opacity = "1";
     }
+    hideMenuButton.style.display = "block";
+  }
 }
 
 /**
@@ -62,62 +62,63 @@ function handleResize() {
  * @param {Event} event - The click event
  */
 function handleOutsideClick(event) {
-    const isClickInside = leftPanel.contains(event.target) || toggleButton.contains(event.target);
-    if (!isClickInside && leftPanel.classList.contains('open')) {
-        hideLeftPanel();
-    }
+  const isClickInside =
+    leftPanel.contains(event.target) || toggleButton.contains(event.target);
+  if (!isClickInside && leftPanel.classList.contains("open")) {
+    hideLeftPanel();
+  }
 }
 
 // Event Listeners for the panel
-document.addEventListener('click', handleOutsideClick);
-window.addEventListener('resize', handleResize);
-hideMenuButton.addEventListener('click', hideLeftPanel);
-toggleButton.addEventListener('click', toggleLeftPanel);
+document.addEventListener("click", handleOutsideClick);
+window.addEventListener("resize", handleResize);
+hideMenuButton.addEventListener("click", hideLeftPanel);
+toggleButton.addEventListener("click", toggleLeftPanel);
 
 /**
  * Initial Setup
  */
 function init() {
-    if (window.innerWidth <= 992) {
-        toggleButton.style.opacity = '1';
-    }
+  if (window.innerWidth <= 992) {
+    toggleButton.style.opacity = "1";
+  }
 }
 
 /**
  * Opens the room info modal with a fade-in animation
  */
 function openRoomInfoModal() {
-    roomInfoModal.style.display = 'flex';
-    // Trigger reflow
-    roomInfoModal.offsetHeight;
-    roomInfoModal.classList.add('show');
+  roomInfoModal.style.display = "flex";
+  // Trigger reflow
+  roomInfoModal.offsetHeight;
+  roomInfoModal.classList.add("show");
 }
 
 /**
  * Closes the room info modal with a fade-out animation
  */
 function closeRoomInfoModal() {
-    roomInfoModal.classList.remove('show');
-    setTimeout(() => {
-        roomInfoModal.style.display = 'none';
-    }, 300);
+  roomInfoModal.classList.remove("show");
+  setTimeout(() => {
+    roomInfoModal.style.display = "none";
+  }, 300);
 }
 
 // Event listeners for room info modal
-learnMoreBtn.addEventListener('click', (e) => {
-    e.preventDefault();
-    openRoomInfoModal();
+learnMoreBtn.addEventListener("click", (e) => {
+  e.preventDefault();
+  openRoomInfoModal();
 });
-closeRoomInfoBtn.addEventListener('click', closeRoomInfoModal);
-roomInfoModal.addEventListener('click', (e) => {
-    if (e.target === roomInfoModal) {
-        closeRoomInfoModal();
-    }
+closeRoomInfoBtn.addEventListener("click", closeRoomInfoModal);
+roomInfoModal.addEventListener("click", (e) => {
+  if (e.target === roomInfoModal) {
+    closeRoomInfoModal();
+  }
 });
-document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && roomInfoModal.classList.contains('show')) {
-        closeRoomInfoModal();
-    }
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && roomInfoModal.classList.contains("show")) {
+    closeRoomInfoModal();
+  }
 });
 
 /**
@@ -125,10 +126,10 @@ document.addEventListener('keydown', (e) => {
  * Sets a cookie with given name, value, and expiration in days
  */
 function setCookie(name, value, days) {
-    const d = new Date();
-    d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
-    const expires = "expires=" + d.toUTCString();
-    document.cookie = name + "=" + value + ";" + expires + ";path=/";
+  const d = new Date();
+  d.setTime(d.getTime() + days * 24 * 60 * 60 * 1000);
+  const expires = "expires=" + d.toUTCString();
+  document.cookie = name + "=" + value + ";" + expires + ";path=/";
 }
 
 /**
@@ -136,35 +137,35 @@ function setCookie(name, value, days) {
  * Returns the cookie value or an empty string if not found
  */
 function getCookie(name) {
-    const nameEQ = name + "=";
-    const ca = document.cookie.split(';');
-    for (let i = 0; i < ca.length; i++) {
-        let c = ca[i].trim();
-        if (c.indexOf(nameEQ) === 0) {
-            return c.substring(nameEQ.length, c.length);
-        }
+  const nameEQ = name + "=";
+  const ca = document.cookie.split(";");
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i].trim();
+    if (c.indexOf(nameEQ) === 0) {
+      return c.substring(nameEQ.length, c.length);
     }
-    return "";
+  }
+  return "";
 }
 
 let dbPromise;
 async function initDB() {
-  dbPromise = idb.openDB('talkomatic-themes', 2, {
+  dbPromise = idb.openDB("talkomatic-themes", 2, {
     upgrade(db, oldVersion, newVersion, transaction) {
       if (oldVersion < 1) {
-        const store = db.createObjectStore('themes', { keyPath: 'id' });
-        store.createIndex('by-date', 'dateAdded');
+        const store = db.createObjectStore("themes", { keyPath: "id" });
+        store.createIndex("by-date", "dateAdded");
       }
       if (oldVersion < 2) {
-        db.createObjectStore('settings', { keyPath: 'key' });
+        db.createObjectStore("settings", { keyPath: "key" });
       }
-    }
+    },
   });
 }
 
 async function getCurrentTheme() {
   const db = await dbPromise;
-  return db.get('settings', 'currentTheme');
+  return db.get("settings", "currentTheme");
 }
 
 /**
@@ -172,119 +173,121 @@ async function getCurrentTheme() {
  * once every 14 days or until they dismiss it.
  */
 function showDiscordInviteNotification() {
-    // If cookie says "true", means user previously dismissed
-    if (getCookie('dismissedDiscordInvite') === 'true') {
-        return; // Do not show again
-    }
+  // If cookie says "true", means user previously dismissed
+  if (getCookie("dismissedDiscordInvite") === "true") {
+    return; // Do not show again
+  }
 
-    // Configure Toastr for a sticky notification (until closed)
-    toastr.options = {
-        closeButton: true,
-        positionClass: "toast-top-right",
-        timeOut: 0,
-        extendedTimeOut: 0,
-        tapToDismiss: false,
-        preventDuplicates: false,
-        showDuration: 300,
-        hideDuration: 300,
-        showEasing: "swing",
-        hideEasing: "linear",
-        showMethod: "fadeIn",
-        hideMethod: "fadeOut"
-    };
+  // Configure Toastr for a sticky notification (until closed)
+  toastr.options = {
+    closeButton: true,
+    positionClass: "toast-top-right",
+    timeOut: 0,
+    extendedTimeOut: 0,
+    tapToDismiss: false,
+    preventDuplicates: false,
+    showDuration: 300,
+    hideDuration: 300,
+    showEasing: "swing",
+    hideEasing: "linear",
+    showMethod: "fadeIn",
+    hideMethod: "fadeOut",
+  };
 
-    const titleText = "Join Our Discord!";
+  const titleText = "Join Our Discord!";
 
-    // Build a small DOM fragment for the toast content
-    const container = document.createElement('div');
-    container.style.display = 'flex';
-    container.style.flexDirection = 'column';
-    container.style.gap = '8px';
+  // Build a small DOM fragment for the toast content
+  const container = document.createElement("div");
+  container.style.display = "flex";
+  container.style.flexDirection = "column";
+  container.style.gap = "8px";
 
-    // A short description
-    const desc = document.createElement('div');
-    desc.textContent = "For community help, support, bug reports, or just to meet others!";
-    container.appendChild(desc);
+  // A short description
+  const desc = document.createElement("div");
+  desc.textContent =
+    "For community help, support, bug reports, or just to meet others!";
+  container.appendChild(desc);
 
-    // A styled button to open Discord
-    const button = document.createElement('button');
-    button.textContent = "Join Discord";
-    button.style.backgroundColor = '#5865F2';
-    button.style.color = '#FFF';
-    button.style.border = 'none';
-    button.style.padding = '6px 12px';
-    button.style.borderRadius = '4px';
-    button.style.cursor = 'pointer';
-    button.style.fontWeight = 'bold';
+  // A styled button to open Discord
+  const button = document.createElement("button");
+  button.textContent = "Join Discord";
+  button.style.backgroundColor = "#5865F2";
+  button.style.color = "#FFF";
+  button.style.border = "none";
+  button.style.padding = "6px 12px";
+  button.style.borderRadius = "4px";
+  button.style.cursor = "pointer";
+  button.style.fontWeight = "bold";
 
-    // Click => open the Discord link in new tab
-    button.addEventListener('click', (e) => {
-        e.stopPropagation(); // So clicking button won't also trigger toast click
-        window.open('https://discord.gg/N7tJznESrE', '_blank');
+  // Click => open the Discord link in new tab
+  button.addEventListener("click", (e) => {
+    e.stopPropagation(); // So clicking button won't also trigger toast click
+    window.open("https://discord.gg/N7tJznESrE", "_blank");
+  });
+  container.appendChild(button);
+
+  // Convert container to HTML for Toastr
+  const contentHTML = container.outerHTML;
+
+  // Show an info toast
+  const $toast = toastr.info(contentHTML, titleText);
+
+  // If the user clicks anywhere on the toast (except the close button),
+  // open the Discord link in a new tab
+  if ($toast) {
+    $toast.on("click", function (e) {
+      // If user didn't click the close button, open the link
+      if (!$(e.target).hasClass("toast-close-button")) {
+        window.open("https://discord.gg/N7tJznESrE", "_blank");
+      }
     });
-    container.appendChild(button);
+  }
 
-    // Convert container to HTML for Toastr
-    const contentHTML = container.outerHTML;
-
-    // Show an info toast
-    const $toast = toastr.info(contentHTML, titleText);
-
-    // If the user clicks anywhere on the toast (except the close button),
-    // open the Discord link in a new tab
-    if ($toast) {
-        $toast.on('click', function(e) {
-            // If user didn't click the close button, open the link
-            if (!$(e.target).hasClass('toast-close-button')) {
-                window.open('https://discord.gg/N7tJznESrE', '_blank');
-            }
-        });
-    }
-
-    // When user clicks the X, set cookie for 14 days
-    if ($toast && $toast.find('.toast-close-button')) {
-        $toast.find('.toast-close-button').on('click', function() {
-            setCookie('dismissedDiscordInvite', 'true', 14);
-        });
-    }
+  // When user clicks the X, set cookie for 14 days
+  if ($toast && $toast.find(".toast-close-button")) {
+    $toast.find(".toast-close-button").on("click", function () {
+      setCookie("dismissedDiscordInvite", "true", 14);
+    });
+  }
 }
 
 // Run after DOM is fully loaded
-document.addEventListener('DOMContentLoaded', async () => {
-    // Basic Toastr options (some overridden above)
-    toastr.options = {
-        closeButton: true,
-        newestOnTop: true,
-        positionClass: "toast-top-right",
-        timeOut: 0,
-        extendedTimeOut: 0,
-        tapToDismiss: true,
-        preventDuplicates: false,
-        showDuration: 300,
-        hideDuration: 300,
-        showEasing: "swing",
-        hideEasing: "linear",
-        showMethod: "fadeIn",
-        hideMethod: "fadeOut"
-    };
+document.addEventListener("DOMContentLoaded", async () => {
+  // Basic Toastr options (some overridden above)
+  toastr.options = {
+    closeButton: true,
+    newestOnTop: true,
+    positionClass: "toast-top-right",
+    timeOut: 0,
+    extendedTimeOut: 0,
+    tapToDismiss: true,
+    preventDuplicates: false,
+    showDuration: 300,
+    hideDuration: 300,
+    showEasing: "swing",
+    hideEasing: "linear",
+    showMethod: "fadeIn",
+    hideMethod: "fadeOut",
+  };
 
-    // Show the Discord invite after a brief delay
-    setTimeout(() => {
-        showDiscordInviteNotification();
-    }, 2000);
+  // Show the Discord invite after a brief delay
+  setTimeout(() => {
+    showDiscordInviteNotification();
+  }, 2000);
 
-    await initDB();
-    const saved = await getCurrentTheme();
-    if (saved && saved.content) {
-        const styleEl = document.createElement("style");
-        (document.head || document.getElementsByTagName('head')[0])
-          .appendChild(styleEl);
-        if (styleEl.styleSheet) {
-            styleEl.styleSheet.cssText = saved.content;
-        } else {
-            styleEl.appendChild(document.createTextNode(saved.content));
-        }
+  await initDB();
+  const saved = await getCurrentTheme();
+  if (saved && saved.content) {
+    const styleEl = document.createElement("style");
+    (document.head || document.getElementsByTagName("head")[0]).appendChild(
+      styleEl,
+    );
+    if (styleEl.styleSheet) {
+      styleEl.styleSheet.cssText = saved.content;
+    } else {
+      styleEl.appendChild(document.createTextNode(saved.content));
     }
+  }
 });
 
 // Run initial setup

--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -283,7 +283,7 @@ function handleAppClick(appId, app) {
     case "fileshare":
       // Coming soon apps
       showInfoModal(
-        `${app.name} is coming soon! We're working hard to bring you this feature.`
+        `${app.name} is coming soon! We're working hard to bring you this feature.`,
       );
       break;
 
@@ -934,7 +934,7 @@ function insertEmoteFromAutocompleteClick(emoteCode, capturedEmoteInfo) {
               chatInput.removeEventListener("input", checkForEmote);
             }
           },
-          { once: true }
+          { once: true },
         );
       }
     }, 10);
@@ -1223,7 +1223,7 @@ function updateVotesUI(votes) {
     const userId = row.dataset.userId;
     const voteButton = row.querySelector(".vote-button");
     const votesAgainstUser = Object.values(votes).filter(
-      (v) => v === userId
+      (v) => v === userId,
     ).length;
 
     if (userId === currentUserId) {
@@ -1265,7 +1265,7 @@ function updateVotesUI(votes) {
 function updateCurrentMessages(messages) {
   Object.keys(messages).forEach((userId) => {
     const chatDiv = document.querySelector(
-      `.chat-row[data-user-id="${userId}"] .chat-input`
+      `.chat-row[data-user-id="${userId}"] .chat-input`,
     );
     if (chatDiv) {
       const messageText = messages[userId].slice(0, MAX_MESSAGE_LENGTH);
@@ -1298,7 +1298,7 @@ function updateCurrentMessages(messages) {
           try {
             setCursorPosition(
               chatDiv,
-              Math.min(cursorPosition, messageText.length)
+              Math.min(cursorPosition, messageText.length),
             );
           } catch (e) {
             console.error("Error restoring cursor:", e);
@@ -1381,7 +1381,7 @@ socket.on("access code required", () => {
           window.location.href = "/index.html";
         });
       }
-    }
+    },
   );
 });
 
@@ -1394,7 +1394,7 @@ socket.on("kicked", () => {
     "You have been removed from the room by a majority vote.",
     () => {
       window.location.href = "/index.html";
-    }
+    },
   );
 });
 
@@ -1403,7 +1403,7 @@ socket.on("room full", () => {
     "This room is full. You will be redirected to the lobby.",
     () => {
       window.location.href = "/index.html";
-    }
+    },
   );
 });
 
@@ -1443,7 +1443,7 @@ socket.on("room not found", () => {
     "The room you are trying to join does not exist or has been deleted. Redirecting to lobby.",
     () => {
       window.location.href = "/index.html";
-    }
+    },
   );
 });
 
@@ -1473,7 +1473,7 @@ socket.on("user left", (userId) => {
   // Only remove the specific user's row
   if (userId !== currentUserId) {
     const userRow = document.querySelector(
-      `.chat-row[data-user-id="${userId}"]`
+      `.chat-row[data-user-id="${userId}"]`,
     );
     if (userRow) {
       userRow.remove();
@@ -1544,7 +1544,7 @@ socket.on("room update", (roomData) => {
   // Restore state
   inputValues.forEach((value, userId) => {
     const chatDiv = document.querySelector(
-      `.chat-row[data-user-id="${userId}"] .chat-input`
+      `.chat-row[data-user-id="${userId}"] .chat-input`,
     );
     if (chatDiv) {
       if (userId === currentUserId) {
@@ -1584,7 +1584,7 @@ socket.on("afk timeout", (data) => {
     data.message ?? "You have been removed from the room due to inactivity.",
     () => {
       window.location.href = data.redirectTo ?? "/";
-    }
+    },
   );
 });
 
@@ -1593,7 +1593,7 @@ socket.on("error", (error) => {
   showErrorModal(
     (error.error.replaceDefaultText ? "" : `An error occurred: `) +
       error.error.message,
-    error.error.code
+    error.error.code,
   );
 });
 
@@ -1783,15 +1783,15 @@ socket.on("offensive word detected", (data) => {
   // DEPRECATED
 
   console.warn(
-    "For talkomatic developers: the 'offensive word detected' event is now deprecated in favor of directly sending the censored text in the 'chat update' event as a bugfix."
+    "For talkomatic developers: the 'offensive word detected' event is now deprecated in favor of directly sending the censored text in the 'chat update' event as a bugfix.",
   );
   console.info(
-    "This is kept for compatibility, but avoid calling this event if necessary."
+    "This is kept for compatibility, but avoid calling this event if necessary.",
   );
 
   const { userId, filteredMessage } = data;
   const chatDiv = document.querySelector(
-    `.chat-row[data-user-id="${userId}"] .chat-input`
+    `.chat-row[data-user-id="${userId}"] .chat-input`,
   );
   if (!chatDiv) return;
 
@@ -1820,7 +1820,7 @@ socket.on("offensive word detected", (data) => {
       try {
         setCursorPosition(
           chatDiv,
-          Math.min(cursorPosition, filteredMessage.length)
+          Math.min(cursorPosition, filteredMessage.length),
         );
       } catch (e) {
         console.error("Error restoring cursor position:", e);
@@ -1831,7 +1831,7 @@ socket.on("offensive word detected", (data) => {
     // Update other user's display
     updateOtherUserMessage(
       chatDiv,
-      filteredMessage.slice(0, MAX_MESSAGE_LENGTH)
+      filteredMessage.slice(0, MAX_MESSAGE_LENGTH),
     );
   }
 });
@@ -1856,7 +1856,7 @@ function getCursorPosition(element) {
         node,
         NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
         null,
-        false
+        false,
       );
 
       while (walker.nextNode()) {
@@ -1895,7 +1895,7 @@ function setCursorPosition(element, position) {
       element,
       NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
       null,
-      false
+      false,
     );
 
     while (walk.nextNode()) {
@@ -2059,7 +2059,7 @@ function displayChatMessage(data) {
   }
 
   const chatRow = document.querySelector(
-    `.chat-row[data-user-id="${data.userId}"]`
+    `.chat-row[data-user-id="${data.userId}"]`,
   );
   if (!chatRow) return;
 
@@ -2310,7 +2310,7 @@ function adjustLayout() {
     const rowGap = 10;
     const totalGap = (chatRows.length - 1) * rowGap;
     const chatRowHeight = Math.floor(
-      (availableHeight - totalGap) / chatRows.length
+      (availableHeight - totalGap) / chatRows.length,
     );
 
     chatRows.forEach((row) => {
@@ -2328,7 +2328,7 @@ function adjustLayout() {
     const columnGap = 10;
     const totalGap = (chatRows.length - 1) * columnGap;
     const chatColumnWidth = Math.floor(
-      (availableWidth - totalGap) / chatRows.length
+      (availableWidth - totalGap) / chatRows.length,
     );
 
     chatRows.forEach((row) => {
@@ -2343,7 +2343,7 @@ function adjustLayout() {
   // Restore focus if needed
   if (activeUserId) {
     const activeInput = document.querySelector(
-      `.chat-row[data-user-id="${activeUserId}"] .chat-input`
+      `.chat-row[data-user-id="${activeUserId}"] .chat-input`,
     );
     if (activeInput) {
       setTimeout(() => {
@@ -2359,7 +2359,7 @@ function handleViewportChange() {
     if (window.visualViewport.height < window.innerHeight) {
       viewport.setAttribute(
         "content",
-        "width=device-width, initial-scale=1, maximum-scale=1"
+        "width=device-width, initial-scale=1, maximum-scale=1",
       );
       document.body.style.height = `${window.visualViewport.height}px`;
     } else {

--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ process.on("unhandledRejection", (reason, promise) => {
   console.error("Promise:", promise);
   console.error(
     "Stack:",
-    reason instanceof Error ? reason.stack : "No stack trace available"
+    reason instanceof Error ? reason.stack : "No stack trace available",
   );
   console.error("=====================================");
 });
@@ -77,7 +77,7 @@ const CONFIG = {
     // NEW: Enhanced features
     ENABLE_STRICT_ANTIBOT: true,
     ENABLE_BOT_TOKENS: true,
-    ENABLE_IP_BASED_USERS: true,
+    ENABLE_IP_BASED_USERS: false,
     REQUIRE_USER_AGENT: true,
   },
   TIMING: {
@@ -125,12 +125,12 @@ let wordFilter;
 try {
   wordFilter = new WordFilter(
     path.join(__dirname, "public", "js", "offensive_words.json"),
-    path.join(__dirname, "public", "js", "character_substitutions.json")
+    path.join(__dirname, "public", "js", "character_substitutions.json"),
   );
 } catch (err) {
   console.error(
     "Failed to initialize WordFilter. Word filtering will be disabled.",
-    err
+    err,
   );
   wordFilter = {
     checkText: () => ({ hasOffensiveWord: false }),
@@ -248,7 +248,7 @@ function detectBrowserRequest(req) {
 
   // Check for common browser indicators
   const hasBrowserUserAgent = /Mozilla|Chrome|Safari|Firefox|Edge|Opera/i.test(
-    userAgent
+    userAgent,
   );
   const hasHtmlAccept = acceptHeader.includes("text/html");
   const hasLanguageHeader = acceptLanguage.length > 0;
@@ -429,7 +429,7 @@ async function enhancedRateLimit(req, res, next) {
       "X-RateLimit-Limit": rateLimitResult.totalHits || "unknown",
       "X-RateLimit-Remaining": rateLimitResult.remainingPoints || 0,
       "X-RateLimit-Reset": new Date(
-        Date.now() + rateLimitResult.msBeforeNext
+        Date.now() + rateLimitResult.msBeforeNext,
       ).toISOString(),
     });
 
@@ -513,14 +513,14 @@ async function handleBotTokenRequest(req, res) {
   ipBotTokenCounts.set(clientIp, currentTokenCount + 1);
 
   console.log(
-    `Bot token generated for ${clientIp}: ${token.substring(0, 10)}...`
+    `Bot token generated for ${clientIp}: ${token.substring(0, 10)}...`,
   );
 
   res.status(201).json({
     token,
     expiresIn: CONFIG.TIMING.BOT_TOKEN_EXPIRY,
     expiresAt: new Date(
-      Date.now() + CONFIG.TIMING.BOT_TOKEN_EXPIRY
+      Date.now() + CONFIG.TIMING.BOT_TOKEN_EXPIRY,
     ).toISOString(),
     usage: {
       rateLimit:
@@ -561,7 +561,7 @@ async function handleBotTokenInfo(req, res) {
     createdAt: new Date(tokenData.createdAt).toISOString(),
     lastUsed: new Date(tokenData.lastUsed).toISOString(),
     expiresAt: new Date(
-      tokenData.createdAt + CONFIG.TIMING.BOT_TOKEN_EXPIRY
+      tokenData.createdAt + CONFIG.TIMING.BOT_TOKEN_EXPIRY,
     ).toISOString(),
     uses: tokenData.uses || 0,
     rateLimit:
@@ -630,7 +630,7 @@ function getRoomStatistics() {
   const currentLimit = calculateCurrentRoomLimit();
   const roomTypes = { public: 0, "semi-private": 0, private: 0 };
   const roomsWithUsers = Array.from(rooms.values()).filter(
-    (room) => room.users && room.users.length > 0
+    (room) => room.users && room.users.length > 0,
   ).length;
   for (const [, room] of rooms) {
     if (roomTypes[room.type] !== undefined) {
@@ -647,7 +647,7 @@ function getRoomStatistics() {
     utilizationPercentage:
       totalRooms > 0
         ? Math.round(
-            (totalUsers / (totalRooms * CONFIG.LIMITS.MAX_ROOM_CAPACITY)) * 100
+            (totalUsers / (totalRooms * CONFIG.LIMITS.MAX_ROOM_CAPACITY)) * 100,
           )
         : 0,
   };
@@ -725,7 +725,7 @@ const corsOptions = {
     }
     return callback(
       new Error("The CORS policy does not allow access from this origin."),
-      false
+      false,
     );
   },
   methods: ["GET", "POST"],
@@ -795,7 +795,7 @@ app.use(
     crossOriginEmbedderPolicy: false,
     crossOriginResourcePolicy: { policy: "cross-origin" },
     crossOriginOpenerPolicy: false,
-  })
+  }),
 );
 
 app.use(xss());
@@ -819,11 +819,6 @@ const limiter = rateLimit({
       code: ERROR_CODES.RATE_LIMITED,
       message: "Too many requests from your IP, please try again later.",
     },
-  },
-
-  onLimitReached: (req, res, options) => {
-    const ip = getClientIP(req);
-    console.warn(`Global rate limit exceeded for IP: ${ip}`);
   },
 });
 
@@ -929,7 +924,7 @@ io.use((socket, next) => {
       if (CONFIG.FEATURES.ENABLE_BOT_TOKENS) {
         if (!botToken) {
           return next(
-            new Error("Bot token required for automated socket access")
+            new Error("Bot token required for automated socket access"),
           );
         }
 
@@ -969,7 +964,7 @@ io.use((socket, next) => {
           const eventName = packet[0];
           if (
             ["error", "connect", "disconnect", "disconnecting"].includes(
-              eventName
+              eventName,
             )
           ) {
             return nextMiddleware();
@@ -990,14 +985,14 @@ io.use((socket, next) => {
             .then(() => nextMiddleware())
             .catch(() => {
               console.warn(
-                `Socket rate limit exceeded for ${eventName} from ${socket.id} (bot: ${socket.isBot})`
+                `Socket rate limit exceeded for ${eventName} from ${socket.id} (bot: ${socket.isBot})`,
               );
               socket.emit(
                 "error",
                 createErrorResponse(
                   ERROR_CODES.RATE_LIMITED,
-                  "Rate limit exceeded: Too many requests per second."
-                )
+                  "Rate limit exceeded: Too many requests per second.",
+                ),
               );
             });
         });
@@ -1034,7 +1029,7 @@ app.use(
         res.setHeader("Content-Type", "font/ttf");
       }
     },
-  })
+  }),
 );
 
 // ============================================================================
@@ -1044,7 +1039,7 @@ function createErrorResponse(
   code,
   message,
   details = null,
-  replaceDefaultText = false
+  replaceDefaultText = false,
 ) {
   const response = { error: { code, message, replaceDefaultText } };
   if (details) response.error.details = details;
@@ -1208,7 +1203,7 @@ function detectBotBehavior(userId, clientIp) {
   userAttempts.push(now);
   // Clean old attempts
   const validAttempts = userAttempts.filter(
-    (time) => now - time < CONFIG.LIMITS.BOT_DETECTION_WINDOW
+    (time) => now - time < CONFIG.LIMITS.BOT_DETECTION_WINDOW,
   );
   userJoinAttempts.set(userId, validAttempts);
   // Track join attempts per IP
@@ -1218,7 +1213,7 @@ function detectBotBehavior(userId, clientIp) {
   const ipAttempts = ipJoinAttempts.get(clientIp);
   ipAttempts.push(now);
   const validIpAttempts = ipAttempts.filter(
-    (time) => now - time < CONFIG.LIMITS.BOT_DETECTION_WINDOW
+    (time) => now - time < CONFIG.LIMITS.BOT_DETECTION_WINDOW,
   );
   ipJoinAttempts.set(clientIp, validIpAttempts);
   // Check for bot behavior
@@ -1228,7 +1223,7 @@ function detectBotBehavior(userId, clientIp) {
     validIpAttempts.length > CONFIG.LIMITS.BOT_DETECTION_JOIN_THRESHOLD * 2;
   if (isBotUser || isBotIp) {
     console.warn(
-      `Bot behavior detected - User: ${userId}, IP: ${clientIp}, UserAttempts: ${validAttempts.length}, IPAttempts: ${validIpAttempts.length}`
+      `Bot behavior detected - User: ${userId}, IP: ${clientIp}, UserAttempts: ${validAttempts.length}, IPAttempts: ${validIpAttempts.length}`,
     );
     suspiciousUsers.set(userId, {
       ip: clientIp,
@@ -1343,7 +1338,7 @@ async function processPendingChatUpdates(userId, socket) {
     try {
       const pointsToConsume = Math.min(
         1 + Math.floor(pendingData.diffs.length / 10),
-        2
+        2,
       );
       await chatUpdateLimiter.consume(userId, pointsToConsume);
     } catch (rateErr) {
@@ -1373,7 +1368,7 @@ async function processPendingChatUpdates(userId, socket) {
         ) {
           diff.text = (diff.text || "").substring(
             0,
-            CONFIG.LIMITS.MAX_MESSAGE_LENGTH - consolidatedMessage.length
+            CONFIG.LIMITS.MAX_MESSAGE_LENGTH - consolidatedMessage.length,
           );
         }
         consolidatedMessage =
@@ -1384,7 +1379,7 @@ async function processPendingChatUpdates(userId, socket) {
         diff.index = Math.min(diff.index, consolidatedMessage.length);
         diff.count = Math.min(
           diff.count,
-          consolidatedMessage.length - diff.index
+          consolidatedMessage.length - diff.index,
         );
         consolidatedMessage =
           consolidatedMessage.slice(0, diff.index) +
@@ -1396,7 +1391,7 @@ async function processPendingChatUpdates(userId, socket) {
           consolidatedMessage.length -
             Math.min(
               replaceTextLength,
-              consolidatedMessage.length - diff.index
+              consolidatedMessage.length - diff.index,
             ) +
             replaceTextLength >
           CONFIG.LIMITS.MAX_MESSAGE_LENGTH
@@ -1407,13 +1402,13 @@ async function processPendingChatUpdates(userId, socket) {
               (consolidatedMessage.length -
                 Math.min(
                   replaceTextLength,
-                  consolidatedMessage.length - diff.index
-                ))
+                  consolidatedMessage.length - diff.index,
+                )),
           );
         }
         const endReplaceIndex = Math.min(
           diff.index + replaceTextLength,
-          consolidatedMessage.length
+          consolidatedMessage.length,
         );
         consolidatedMessage =
           consolidatedMessage.slice(0, diff.index) +
@@ -1460,7 +1455,7 @@ async function processPendingChatUpdates(userId, socket) {
         userId,
         setTimeout(() => {
           processPendingChatUpdates(userId, socket);
-        }, CONFIG.TIMING.BATCH_PROCESSING_INTERVAL)
+        }, CONFIG.TIMING.BATCH_PROCESSING_INTERVAL),
       );
     } else {
       pendingChatUpdates.delete(userId);
@@ -1492,7 +1487,7 @@ function checkChatCircuit() {
     chatCircuitState.isOpen = true;
     chatCircuitState.lastFailure = now;
     console.warn(
-      `Chat circuit breaker opened after ${chatCircuitState.failures} failures`
+      `Chat circuit breaker opened after ${chatCircuitState.failures} failures`,
     );
   }
   return !chatCircuitState.isOpen;
@@ -1511,7 +1506,7 @@ async function saveRooms() {
     const timeSinceLastSave = now - lastSaveTimestamp;
     if (timeSinceLastSave < SAVE_INTERVAL_MIN) {
       console.log(
-        `Skipping room save (last save was ${timeSinceLastSave}ms ago)`
+        `Skipping room save (last save was ${timeSinceLastSave}ms ago)`,
       );
       return;
     }
@@ -1556,13 +1551,27 @@ async function loadRooms() {
   try {
     const roomsData = await fs.readFile(
       path.join(__dirname, "rooms.json"),
-      "utf8"
+      "utf8",
     );
     const loadedRoomsArray = JSON.parse(roomsData);
     if (Array.isArray(loadedRoomsArray)) {
       rooms = new Map(
         loadedRoomsArray.map((item) => {
           if (item[1]) {
+            // ====== FIX: Clear users from loaded rooms ======
+            // These users had socket connections to the previous server process.
+            // They have no active sockets now, so they'd be permanent ghosts.
+            const userCount = item[1].users ? item[1].users.length : 0;
+            if (userCount > 0) {
+              console.log(
+                `Clearing ${userCount} stale user(s) from loaded room: ${item[1].name || item[0]}`,
+              );
+            }
+            item[1].users = [];
+            // Reset lastActiveTime so deletion timer logic works correctly
+            item[1].lastActiveTime = Date.now();
+            // ====== END FIX ======
+
             if (item[1].bannedUserIds) {
               if (item[1].bannedUserIds instanceof Set) {
                 // Already a Set
@@ -1570,7 +1579,7 @@ async function loadRooms() {
                 item[1].bannedUserIds = new Set(item[1].bannedUserIds);
               } else if (typeof item[1].bannedUserIds === "object") {
                 item[1].bannedUserIds = new Set(
-                  Object.values(item[1].bannedUserIds)
+                  Object.values(item[1].bannedUserIds),
                 );
               } else {
                 item[1].bannedUserIds = new Set();
@@ -1580,12 +1589,23 @@ async function loadRooms() {
             }
           }
           return item;
-        })
+        }),
       );
-      console.log(`Loaded ${rooms.size} rooms from disk.`);
+      console.log(`Loaded ${rooms.size} rooms from disk (all users cleared).`);
+
+      // ====== FIX: Start deletion timers for all loaded (now-empty) rooms ======
+      for (const [roomId, room] of rooms) {
+        if (!room.users || room.users.length === 0) {
+          startRoomDeletionTimer(roomId);
+          console.log(
+            `Started deletion timer for empty loaded room: ${roomId}`,
+          );
+        }
+      }
+      // ====== END FIX ======
     } else {
       console.warn(
-        "rooms.json was not in the expected format. Starting with empty rooms."
+        "rooms.json was not in the expected format. Starting with empty rooms.",
       );
       rooms = new Map();
     }
@@ -1597,7 +1617,7 @@ async function loadRooms() {
       console.error(
         "Error loading rooms:",
         error,
-        ". Starting with empty rooms map."
+        ". Starting with empty rooms map.",
       );
       rooms = new Map();
     }
@@ -1725,7 +1745,7 @@ async function leaveRoom(socket, userId) {
       }
       socket.handshake.session.currentRoom = null;
       await promisifySessionSave(socket.handshake.session).catch((err) =>
-        console.error("Session save failed in leaveRoom:", err)
+        console.error("Session save failed in leaveRoom:", err),
       );
     }
     userMessageBuffers.delete(userId);
@@ -1740,8 +1760,8 @@ async function leaveRoom(socket, userId) {
         "error",
         createErrorResponse(
           ERROR_CODES.SERVER_ERROR,
-          "Error processing leave room."
-        )
+          "Error processing leave room.",
+        ),
       );
     }
   }
@@ -1754,8 +1774,8 @@ function joinRoom(socket, roomId, userId) {
         "error",
         createErrorResponse(
           ERROR_CODES.NOT_FOUND,
-          "Room not found (invalid ID format)."
-        )
+          "Room not found (invalid ID format).",
+        ),
       );
       return;
     }
@@ -1763,7 +1783,7 @@ function joinRoom(socket, roomId, userId) {
     if (!room) {
       socket.emit(
         "error",
-        createErrorResponse(ERROR_CODES.NOT_FOUND, "Room not found.")
+        createErrorResponse(ERROR_CODES.NOT_FOUND, "Room not found."),
       );
       return;
     }
@@ -1772,8 +1792,8 @@ function joinRoom(socket, roomId, userId) {
         "error",
         createErrorResponse(
           ERROR_CODES.FORBIDDEN,
-          "You have been banned from rejoining this room."
-        )
+          "You have been banned from rejoining this room.",
+        ),
       );
       return;
     }
@@ -1795,8 +1815,8 @@ function joinRoom(socket, roomId, userId) {
           "error",
           createErrorResponse(
             ERROR_CODES.FORBIDDEN,
-            "Access denied due to suspicious activity. Please try again later."
-          )
+            "Access denied due to suspicious activity. Please try again later.",
+          ),
         );
         return;
       }
@@ -1805,8 +1825,8 @@ function joinRoom(socket, roomId, userId) {
           "error",
           createErrorResponse(
             ERROR_CODES.RATE_LIMITED,
-            "Too many room join attempts. Please slow down and try again later."
-          )
+            "Too many room join attempts. Please slow down and try again later.",
+          ),
         );
         return;
       }
@@ -1824,22 +1844,22 @@ function joinRoom(socket, roomId, userId) {
             ERROR_CODES.FORBIDDEN,
             `You are already in a room: "${currentRoomName}". Please leave that room first before joining another one.`,
             { currentRoomId, currentRoomName },
-            true
-          )
+            true,
+          ),
         );
         return;
       }
       const sameNameLocCount = getUsernameLocationRoomsCount(
         username,
-        location
+        location,
       );
       if (sameNameLocCount >= CONFIG.LIMITS.MAX_ROOMS_PER_USER) {
         socket.emit(
           "error",
           createErrorResponse(
             ERROR_CODES.FORBIDDEN,
-            "This username/location combination is already in a room. Please leave that room first."
-          )
+            "This username/location combination is already in a room. Please leave that room first.",
+          ),
         );
         return;
       }
@@ -1851,7 +1871,7 @@ function joinRoom(socket, roomId, userId) {
     if (room.users.length >= CONFIG.LIMITS.MAX_ROOM_CAPACITY) {
       socket.emit(
         "room full",
-        createErrorResponse(ERROR_CODES.ROOM_FULL, "This room is full.")
+        createErrorResponse(ERROR_CODES.ROOM_FULL, "This room is full."),
       );
       return;
     }
@@ -1874,8 +1894,8 @@ function joinRoom(socket, roomId, userId) {
             "error",
             createErrorResponse(
               ERROR_CODES.SERVER_ERROR,
-              "Failed to save session on joining room."
-            )
+              "Failed to save session on joining room.",
+            ),
           );
           return;
         }
@@ -1886,7 +1906,7 @@ function joinRoom(socket, roomId, userId) {
       emitJoinRoomSuccess(socket, room, userId, username, location);
     }
     debouncedSaveRooms().catch((err) =>
-      console.error("Failed to save rooms after join:", err)
+      console.error("Failed to save rooms after join:", err),
     );
   } catch (err) {
     console.error("Critical error in joinRoom logic:", err);
@@ -1894,8 +1914,8 @@ function joinRoom(socket, roomId, userId) {
       "error",
       createErrorResponse(
         ERROR_CODES.SERVER_ERROR,
-        "An unexpected error occurred while joining the room."
-      )
+        "An unexpected error occurred while joining the room.",
+      ),
     );
   }
 }
@@ -1948,7 +1968,7 @@ function handleTyping(socket, userId, username, isTyping) {
             .to(socket.roomId)
             .emit("user typing", { userId, username, isTyping: false });
           typingTimeouts.delete(userId);
-        }, CONFIG.TIMING.TYPING_TIMEOUT)
+        }, CONFIG.TIMING.TYPING_TIMEOUT),
       );
     } else {
       socket
@@ -1975,7 +1995,7 @@ loadRooms().catch((err) => {
 // Apply antibot and enhanced rate limiting to API routes
 app.post(
   `/api/${CONFIG.VERSIONS.API}/bot-tokens/request`,
-  handleBotTokenRequest
+  handleBotTokenRequest,
 );
 app.get(`/api/${CONFIG.VERSIONS.API}/bot-tokens/info`, handleBotTokenInfo);
 
@@ -2060,7 +2080,7 @@ app.get("/js/emojiList.json", async (req, res) => {
       __dirname,
       "public",
       "js",
-      "emojiList.json"
+      "emojiList.json",
     );
     const data = await fs.readFile(emojiListPath, "utf8");
     emojiListCache.data = data;
@@ -2085,7 +2105,7 @@ function apiAuth(req, res, next) {
       res,
       ERROR_CODES.UNAUTHORIZED,
       "Forbidden: invalid or missing x-api-key.",
-      403
+      403,
     );
   }
   next();
@@ -2126,7 +2146,7 @@ app.get(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, (req, res) => {
       res,
       ERROR_CODES.SERVER_ERROR,
       "Internal server error",
-      500
+      500,
     );
   }
 });
@@ -2147,7 +2167,7 @@ app.get(`/api/${CONFIG.VERSIONS.API}/rooms/:id`, apiAuth, (req, res) => {
         res,
         ERROR_CODES.NOT_FOUND,
         "Room not found",
-        404
+        404,
       );
     const roomData = {
       id: room.id,
@@ -2172,7 +2192,7 @@ app.get(`/api/${CONFIG.VERSIONS.API}/rooms/:id`, apiAuth, (req, res) => {
       res,
       ERROR_CODES.SERVER_ERROR,
       "Internal server error",
-      500
+      500,
     );
   }
 });
@@ -2192,7 +2212,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
         ERROR_CODES.VALIDATION_ERROR,
         "Validation failed",
         400,
-        validationErrors
+        validationErrors,
       );
     }
     // Enhanced room limit check with dynamic scaling
@@ -2203,7 +2223,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
         res,
         ERROR_CODES.ROOM_LIMIT_REACHED,
         `Server has reached its current room limit (${currentLimit} rooms). Current usage: ${stats.totalUsers} users in ${stats.totalRooms} rooms.`,
-        429
+        429,
       );
     }
     // Check for room creation cooldown
@@ -2217,7 +2237,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
         res,
         ERROR_CODES.RATE_LIMITED,
         "Creating rooms too frequently.",
-        429
+        429,
       );
     }
     let roomName = enforceRoomNameLimit(data.name);
@@ -2227,7 +2247,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
         res,
         ERROR_CODES.ROOM_NAME_EXISTS,
         "A room with this name already exists. Please choose a different name.",
-        409
+        409,
       );
     }
     if (CONFIG.FEATURES.ENABLE_WORD_FILTER) {
@@ -2237,7 +2257,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
           res,
           ERROR_CODES.VALIDATION_ERROR,
           "Room name contains forbidden words.",
-          400
+          400,
         );
       }
     }
@@ -2252,7 +2272,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
           res,
           ERROR_CODES.SERVER_ERROR,
           "Could not create room, server busy. Try again.",
-          500
+          500,
         );
       }
     } while (rooms.has(roomId));
@@ -2273,7 +2293,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
       if (!req.session.validatedRooms) req.session.validatedRooms = {};
       req.session.validatedRooms[roomId] = data.accessCode;
       await promisifySessionSave(req.session).catch((err) =>
-        console.error("API session save error:", err)
+        console.error("API session save error:", err),
       );
     }
     // Invalidate caches
@@ -2283,7 +2303,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
     // Log room creation with statistics
     const stats = getRoomStatistics();
     console.log(
-      `Room created: ${roomId} (${roomName}) | Current: ${stats.totalRooms}/${stats.currentLimit} rooms, ${stats.totalUsers} users`
+      `Room created: ${roomId} (${roomName}) | Current: ${stats.totalRooms}/${stats.currentLimit} rooms, ${stats.totalUsers} users`,
     );
     return res.status(201).json({
       success: true,
@@ -2296,7 +2316,7 @@ app.post(`/api/${CONFIG.VERSIONS.API}/rooms`, apiAuth, async (req, res) => {
       res,
       ERROR_CODES.SERVER_ERROR,
       "Internal server error",
-      500
+      500,
     );
   }
 });
@@ -2313,14 +2333,14 @@ app.post(
           res,
           ERROR_CODES.NOT_FOUND,
           "Room not found",
-          404
+          404,
         );
       if (room.users.length >= CONFIG.LIMITS.MAX_ROOM_CAPACITY) {
         return sendErrorResponse(
           res,
           ERROR_CODES.ROOM_FULL,
           "Room is full",
-          400
+          400,
         );
       }
       if (room.type === "semi-private") {
@@ -2334,7 +2354,7 @@ app.post(
               res,
               ERROR_CODES.FORBIDDEN,
               "Access code required",
-              403
+              403,
             );
           if (
             typeof req.body.accessCode !== "string" ||
@@ -2345,7 +2365,7 @@ app.post(
               res,
               ERROR_CODES.VALIDATION_ERROR,
               "Invalid access code format",
-              400
+              400,
             );
           }
           if (room.accessCode !== req.body.accessCode) {
@@ -2353,14 +2373,14 @@ app.post(
               res,
               ERROR_CODES.FORBIDDEN,
               "Incorrect access code",
-              403
+              403,
             );
           }
           if (req.session) {
             if (!req.session.validatedRooms) req.session.validatedRooms = {};
             req.session.validatedRooms[roomId] = req.body.accessCode;
             await promisifySessionSave(req.session).catch((err) =>
-              console.error("API join session save error:", err)
+              console.error("API join session save error:", err),
             );
           }
         }
@@ -2375,10 +2395,10 @@ app.post(
         res,
         ERROR_CODES.SERVER_ERROR,
         "Internal server error",
-        500
+        500,
       );
     }
-  }
+  },
 );
 
 // ============================================================================
@@ -2397,20 +2417,20 @@ io.on("connection", (socket) => {
           `Socket handler error in ${
             fn.name || "unnamed handler"
           } from ${clientIp}:`,
-          err
+          err,
         );
         try {
           socket.emit(
             "error",
             createErrorResponse(
               ERROR_CODES.SERVER_ERROR,
-              "Internal server error processing your request."
-            )
+              "Internal server error processing your request.",
+            ),
           );
           socket._errorCount = (socket._errorCount || 0) + 1;
           if (socket._errorCount > 10) {
             console.warn(
-              `Disconnecting socket ${socket.id} after multiple errors`
+              `Disconnecting socket ${socket.id} after multiple errors`,
             );
             socket.disconnect(true);
           }
@@ -2465,7 +2485,7 @@ io.on("connection", (socket) => {
           socket.handshake.session.isIPBased = true;
 
           await promisifySessionSave(socket.handshake.session).catch((err) =>
-            console.error("Session save error for IP user:", err)
+            console.error("Session save error for IP user:", err),
           );
         }
       }
@@ -2488,7 +2508,7 @@ io.on("connection", (socket) => {
           isBot: !!socket.isBot,
         });
       }
-    })
+    }),
   );
 
   socket.on(
@@ -2499,8 +2519,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.BAD_REQUEST,
-            "Invalid data for joining lobby."
-          )
+            "Invalid data for joining lobby.",
+          ),
         );
         return;
       }
@@ -2520,8 +2540,8 @@ io.on("connection", (socket) => {
             "error",
             createErrorResponse(
               ERROR_CODES.VALIDATION_ERROR,
-              "Username contains forbidden words."
-            )
+              "Username contains forbidden words.",
+            ),
           );
           return;
         }
@@ -2530,8 +2550,8 @@ io.on("connection", (socket) => {
             "error",
             createErrorResponse(
               ERROR_CODES.VALIDATION_ERROR,
-              "Location contains forbidden words."
-            )
+              "Location contains forbidden words.",
+            ),
           );
           return;
         }
@@ -2542,8 +2562,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.SERVER_ERROR,
-            "Session not available."
-          )
+            "Session not available.",
+          ),
         );
         return;
       }
@@ -2557,8 +2577,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.SERVER_ERROR,
-            "Failed to save session."
-          )
+            "Failed to save session.",
+          ),
         );
         throw err;
       });
@@ -2573,7 +2593,7 @@ io.on("connection", (socket) => {
         isIPBased: false,
         isBot: !!socket.isBot,
       });
-    })
+    }),
   );
 
   socket.on(
@@ -2584,8 +2604,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.BAD_REQUEST,
-            "Invalid data for creating room."
-          )
+            "Invalid data for creating room.",
+          ),
         );
         return;
       }
@@ -2597,8 +2617,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.UNAUTHORIZED,
-            "You must be signed in to create a room."
-          )
+            "You must be signed in to create a room.",
+          ),
         );
         return;
       }
@@ -2621,8 +2641,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.FORBIDDEN,
-            "Anonymous users cannot create rooms."
-          )
+            "Anonymous users cannot create rooms.",
+          ),
         );
         return;
       }
@@ -2634,8 +2654,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.ROOM_LIMIT_REACHED,
-            `Server has reached its current room limit (${currentLimit} rooms). Current usage: ${stats.totalUsers} users in ${stats.totalRooms} rooms.`
-          )
+            `Server has reached its current room limit (${currentLimit} rooms). Current usage: ${stats.totalUsers} users in ${stats.totalRooms} rooms.`,
+          ),
         );
         return;
       }
@@ -2648,8 +2668,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.FORBIDDEN,
-            "You are already in a room. Please leave that room first before creating a new one."
-          )
+            "You are already in a room. Please leave that room first before creating a new one.",
+          ),
         );
         return;
       }
@@ -2658,8 +2678,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.FORBIDDEN,
-            "You are already in a room. Please leave that room first before creating a new one."
-          )
+            "You are already in a room. Please leave that room first before creating a new one.",
+          ),
         );
         return;
       }
@@ -2673,8 +2693,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.RATE_LIMITED,
-            "Creating rooms too frequently."
-          )
+            "Creating rooms too frequently.",
+          ),
         );
         return;
       }
@@ -2685,8 +2705,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.ROOM_NAME_EXISTS,
-            "A room with this name already exists. Please choose a different name."
-          )
+            "A room with this name already exists. Please choose a different name.",
+          ),
         );
         return;
       }
@@ -2698,8 +2718,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.VALIDATION_ERROR,
-            "Room name contains forbidden words."
-          )
+            "Room name contains forbidden words.",
+          ),
         );
         return;
       }
@@ -2716,8 +2736,8 @@ io.on("connection", (socket) => {
             "error",
             createErrorResponse(
               ERROR_CODES.SERVER_ERROR,
-              "Could not generate unique room ID. Try again."
-            )
+              "Could not generate unique room ID. Try again.",
+            ),
           );
           return;
         }
@@ -2741,7 +2761,7 @@ io.on("connection", (socket) => {
           socket.handshake.session.validatedRooms = {};
         socket.handshake.session.validatedRooms[roomId] = data.accessCode;
         await promisifySessionSave(socket.handshake.session).catch((err) =>
-          console.error("Session save error (create room):", err)
+          console.error("Session save error (create room):", err),
         );
       }
       // Invalidate caches
@@ -2752,9 +2772,9 @@ io.on("connection", (socket) => {
       // Log room creation with statistics
       const stats = getRoomStatistics();
       console.log(
-        `Room created via socket: ${roomId} (${roomName}) | Current: ${stats.totalRooms}/${stats.currentLimit} rooms, ${stats.totalUsers} users`
+        `Room created via socket: ${roomId} (${roomName}) | Current: ${stats.totalRooms}/${stats.currentLimit} rooms, ${stats.totalUsers} users`,
       );
-    })
+    }),
   );
 
   socket.on(
@@ -2765,8 +2785,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.BAD_REQUEST,
-            "Invalid data for joining room."
-          )
+            "Invalid data for joining room.",
+          ),
         );
         return;
       }
@@ -2774,7 +2794,7 @@ io.on("connection", (socket) => {
       if (!room) {
         socket.emit(
           "room not found",
-          createErrorResponse(ERROR_CODES.NOT_FOUND, "Room not found.")
+          createErrorResponse(ERROR_CODES.NOT_FOUND, "Room not found."),
         );
         return;
       }
@@ -2788,14 +2808,16 @@ io.on("connection", (socket) => {
           if (!location) socket.handshake.session.location = "On The Web";
         } else {
           console.error(
-            "No session available for socket " + socket.id + " during join room"
+            "No session available for socket " +
+              socket.id +
+              " during join room",
           );
           socket.emit(
             "error",
             createErrorResponse(
               ERROR_CODES.SERVER_ERROR,
-              "Session error, cannot join room."
-            )
+              "Session error, cannot join room.",
+            ),
           );
           return;
         }
@@ -2817,8 +2839,8 @@ io.on("connection", (socket) => {
               ERROR_CODES.FORBIDDEN,
               `You are already in a room: "${currentRoomName}". Please leave that room first before joining another one.`,
               { currentRoomId, currentRoomName },
-              true
-            )
+              true,
+            ),
           );
           return;
         }
@@ -2844,15 +2866,18 @@ io.on("connection", (socket) => {
             "error",
             createErrorResponse(
               ERROR_CODES.VALIDATION_ERROR,
-              "Invalid access code format."
-            )
+              "Invalid access code format.",
+            ),
           );
           return;
         }
         if (room.accessCode !== codeToUse) {
           socket.emit(
             "error",
-            createErrorResponse(ERROR_CODES.FORBIDDEN, "Incorrect access code.")
+            createErrorResponse(
+              ERROR_CODES.FORBIDDEN,
+              "Incorrect access code.",
+            ),
           );
           return;
         }
@@ -2861,12 +2886,12 @@ io.on("connection", (socket) => {
             socket.handshake.session.validatedRooms = {};
           socket.handshake.session.validatedRooms[data.roomId] = codeToUse;
           await promisifySessionSave(socket.handshake.session).catch((err) =>
-            console.error("Session save error (join room access code):", err)
+            console.error("Session save error (join room access code):", err),
           );
         }
       }
       joinRoom(socket, data.roomId, userId);
-    })
+    }),
   );
 
   socket.on(
@@ -2875,7 +2900,7 @@ io.on("connection", (socket) => {
       if (!data || typeof data !== "object" || !data.targetUserId) {
         socket.emit(
           "error",
-          createErrorResponse(ERROR_CODES.BAD_REQUEST, "Invalid vote data.")
+          createErrorResponse(ERROR_CODES.BAD_REQUEST, "Invalid vote data."),
         );
         return;
       }
@@ -2896,13 +2921,13 @@ io.on("connection", (socket) => {
       io.to(roomId).emit("update votes", room.votes);
       // Check if user should be kicked
       const votesAgainstTarget = Object.values(room.votes).filter(
-        (v) => v === targetUserId
+        (v) => v === targetUserId,
       ).length;
       const totalUsers = room.users.length;
       if (totalUsers >= 3 && votesAgainstTarget > Math.floor(totalUsers / 2)) {
         const targetSocket = [...io.sockets.sockets.values()].find(
           (s) =>
-            s.handshake.session.userId === targetUserId && s.roomId === roomId
+            s.handshake.session.userId === targetUserId && s.roomId === roomId,
         );
         if (targetSocket) {
           targetSocket.emit("kicked");
@@ -2911,7 +2936,7 @@ io.on("connection", (socket) => {
           await leaveRoom(targetSocket, targetUserId);
         }
       }
-    })
+    }),
   );
 
   socket.on(
@@ -2924,7 +2949,7 @@ io.on("connection", (socket) => {
         clearAFKTimers(userId);
         await leaveRoom(socket, userId);
       }
-    })
+    }),
   );
 
   socket.on(
@@ -2935,8 +2960,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.CIRCUIT_OPEN,
-            "System is temporarily unavailable. Please try again later."
-          )
+            "System is temporarily unavailable. Please try again later.",
+          ),
         );
         return;
       }
@@ -2957,8 +2982,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.BAD_REQUEST,
-            "Invalid chat update data format."
-          )
+            "Invalid chat update data format.",
+          ),
         );
         return;
       }
@@ -2967,7 +2992,7 @@ io.on("connection", (socket) => {
       if (!["full-replace", "add", "delete", "replace"].includes(diff.type)) {
         socket.emit(
           "error",
-          createErrorResponse(ERROR_CODES.BAD_REQUEST, "Unknown diff type.")
+          createErrorResponse(ERROR_CODES.BAD_REQUEST, "Unknown diff type."),
         );
         return;
       }
@@ -2982,8 +3007,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.BAD_REQUEST,
-            "Diff text must be a string."
-          )
+            "Diff text must be a string.",
+          ),
         );
         return;
       }
@@ -2996,7 +3021,7 @@ io.on("connection", (socket) => {
       ) {
         socket.emit(
           "error",
-          createErrorResponse(ERROR_CODES.BAD_REQUEST, "Invalid diff index.")
+          createErrorResponse(ERROR_CODES.BAD_REQUEST, "Invalid diff index."),
         );
         return;
       }
@@ -3009,8 +3034,8 @@ io.on("connection", (socket) => {
           "error",
           createErrorResponse(
             ERROR_CODES.BAD_REQUEST,
-            "Invalid diff count for delete."
-          )
+            "Invalid diff count for delete.",
+          ),
         );
         return;
       }
@@ -3026,10 +3051,10 @@ io.on("connection", (socket) => {
           userId,
           setTimeout(() => {
             processPendingChatUpdates(userId, socket);
-          }, CONFIG.TIMING.BATCH_PROCESSING_INTERVAL)
+          }, CONFIG.TIMING.BATCH_PROCESSING_INTERVAL),
         );
       }
-    })
+    }),
   );
 
   socket.on(
@@ -3055,7 +3080,7 @@ io.on("connection", (socket) => {
       });
       if (!data || typeof data.isTyping !== "boolean") return;
       handleTyping(socket, userId, username, data.isTyping);
-    })
+    }),
   );
 
   socket.on(
@@ -3089,7 +3114,7 @@ io.on("connection", (socket) => {
         apiCache.set(cacheKey, { timestamp: Date.now(), data: publicRooms });
       }
       socket.emit("initial rooms", publicRooms);
-    })
+    }),
   );
 
   socket.on(
@@ -3098,7 +3123,7 @@ io.on("connection", (socket) => {
       if (!roomId || typeof roomId !== "string") {
         socket.emit(
           "error",
-          createErrorResponse(ERROR_CODES.BAD_REQUEST, "Room ID is required.")
+          createErrorResponse(ERROR_CODES.BAD_REQUEST, "Room ID is required."),
         );
         return;
       }
@@ -3106,7 +3131,7 @@ io.on("connection", (socket) => {
       if (!room) {
         socket.emit(
           "error",
-          createErrorResponse(ERROR_CODES.NOT_FOUND, "Room not found.")
+          createErrorResponse(ERROR_CODES.NOT_FOUND, "Room not found."),
         );
         return;
       }
@@ -3120,7 +3145,7 @@ io.on("connection", (socket) => {
         currentMessages: getCurrentMessages(room.users),
         isFull: room.users.length >= CONFIG.LIMITS.MAX_ROOM_CAPACITY,
       });
-    })
+    }),
   );
 
   socket.on(
@@ -3158,9 +3183,9 @@ io.on("connection", (socket) => {
       console.log(
         `User "${username}" from "${location}" disconnected. Reason: ${reason}. IP: ${
           socket.clientIp
-        }${socket.isBot ? " [BOT]" : ""}`
+        }${socket.isBot ? " [BOT]" : ""}`,
       );
-    })
+    }),
   );
 
   socket.on(
@@ -3170,7 +3195,7 @@ io.on("connection", (socket) => {
       if (!userId || !socket.roomId) return;
       setupAFKTimers(socket, userId);
       console.log(`AFK response from user ${userId}: ${JSON.stringify(data)}`);
-    })
+    }),
   );
 });
 
@@ -3184,7 +3209,7 @@ setInterval(() => {
   // Clean up old join attempts
   for (const [userId, attempts] of userJoinAttempts.entries()) {
     const validAttempts = attempts.filter(
-      (time) => now - time < CONFIG.LIMITS.BOT_DETECTION_WINDOW
+      (time) => now - time < CONFIG.LIMITS.BOT_DETECTION_WINDOW,
     );
     if (validAttempts.length === 0) {
       userJoinAttempts.delete(userId);
@@ -3194,7 +3219,7 @@ setInterval(() => {
   }
   for (const [ip, attempts] of ipJoinAttempts.entries()) {
     const validAttempts = attempts.filter(
-      (time) => now - time < CONFIG.LIMITS.BOT_DETECTION_WINDOW
+      (time) => now - time < CONFIG.LIMITS.BOT_DETECTION_WINDOW,
     );
     if (validAttempts.length === 0) {
       ipJoinAttempts.delete(ip);
@@ -3326,7 +3351,7 @@ setInterval(async () => {
     if (deletedCount > 0) {
       const stats = getRoomStatistics();
       console.log(
-        `Cleaned up ${deletedCount} empty rooms. Current: ${stats.totalRooms}/${stats.currentLimit} rooms, ${stats.totalUsers} users`
+        `Cleaned up ${deletedCount} empty rooms. Current: ${stats.totalRooms}/${stats.currentLimit} rooms, ${stats.totalUsers} users`,
       );
     }
   } catch (err) {
@@ -3334,43 +3359,135 @@ setInterval(async () => {
   }
 }, 600000); // Every 10 minutes
 
+// Ghost user cleanup — validates room users against active socket connections
+setInterval(() => {
+  try {
+    // Build a Set of all userIds that have active socket connections
+    const activeSocketUserIds = new Set();
+    for (const [, socket] of io.sockets.sockets) {
+      const userId = socket.handshake?.session?.userId;
+      if (userId) {
+        activeSocketUserIds.add(userId);
+      }
+    }
+
+    let totalGhostsRemoved = 0;
+    const roomsToCheck = [];
+
+    for (const [roomId, room] of rooms) {
+      if (!room.users || room.users.length === 0) continue;
+
+      const beforeCount = room.users.length;
+
+      // Filter out any user that doesn't have an active socket connection
+      room.users = room.users.filter((user) => {
+        const hasSocket = activeSocketUserIds.has(user.id);
+        if (!hasSocket) {
+          console.log(
+            `Ghost user detected and removed: "${user.username}" (${user.id}) from room "${room.name}" (${roomId})`,
+          );
+          // Clean up associated resources
+          userMessageBuffers.delete(user.id);
+          clearAFKTimers(user.id);
+          if (typingTimeouts.has(user.id)) {
+            clearTimeout(typingTimeouts.get(user.id));
+            typingTimeouts.delete(user.id);
+          }
+          if (batchProcessingTimers.has(user.id)) {
+            clearTimeout(batchProcessingTimers.get(user.id));
+            batchProcessingTimers.delete(user.id);
+            pendingChatUpdates.delete(user.id);
+          }
+        }
+        return hasSocket;
+      });
+
+      const removedCount = beforeCount - room.users.length;
+      if (removedCount > 0) {
+        totalGhostsRemoved += removedCount;
+        roomsToCheck.push(roomId);
+
+        // Clean up votes referencing removed users
+        if (room.votes) {
+          for (const visibleUserId of Object.keys(room.votes)) {
+            if (!activeSocketUserIds.has(visibleUserId)) {
+              delete room.votes[visibleUserId];
+            }
+          }
+          for (const [voterId, targetId] of Object.entries(room.votes)) {
+            if (!activeSocketUserIds.has(targetId)) {
+              delete room.votes[voterId];
+            }
+          }
+        }
+      }
+    }
+
+    // Start deletion timers for rooms that are now empty
+    for (const roomId of roomsToCheck) {
+      const room = rooms.get(roomId);
+      if (room) {
+        updateRoom(roomId);
+        if (room.users.length === 0) {
+          startRoomDeletionTimer(roomId);
+        }
+      }
+    }
+
+    if (totalGhostsRemoved > 0) {
+      console.log(
+        `Ghost cleanup: removed ${totalGhostsRemoved} ghost user(s) from ${roomsToCheck.length} room(s)`,
+      );
+      updateLobby();
+      debouncedSaveRooms().catch((err) =>
+        console.error("Failed to save rooms after ghost cleanup:", err),
+      );
+    }
+  } catch (err) {
+    console.error("Error in ghost user cleanup:", err);
+  }
+}, 60000); // Every 1 minute
+
 // Enhanced server monitoring with bot token statistics
 setInterval(() => {
   try {
     const memoryUsage = process.memoryUsage();
     const heapUsedPercentage = Math.round(
-      (memoryUsage.heapUsed / memoryUsage.heapTotal) * 100
+      (memoryUsage.heapUsed / memoryUsage.heapTotal) * 100,
     );
     const stats = getRoomStatistics();
     // Log current server status
     console.log(`=== ENHANCED SERVER STATUS ===`);
     console.log(`Connected clients: ${io.sockets.sockets.size}`);
     console.log(
-      `Rooms: ${stats.totalRooms}/${stats.currentLimit} (${stats.emptyRooms} empty)`
+      `Rooms: ${stats.totalRooms}/${stats.currentLimit} (${stats.emptyRooms} empty)`,
     );
     console.log(
-      `Users: ${stats.totalUsers} (${stats.utilizationPercentage}% utilization)`
+      `Users: ${stats.totalUsers} (${stats.utilizationPercentage}% utilization)`,
     );
     console.log(
-      `Room types: Public: ${stats.roomTypes.public}, Semi-Private: ${stats.roomTypes["semi-private"]}, Private: ${stats.roomTypes.private}`
+      `Room types: Public: ${stats.roomTypes.public}, Semi-Private: ${stats.roomTypes["semi-private"]}, Private: ${stats.roomTypes.private}`,
     );
     console.log(`Active bot tokens: ${botTokens.size}`);
     console.log(`IP-based users: ${ipBasedUsers.size}`);
     console.log(`Memory: ${heapUsedPercentage}% heap usage`);
     console.log(`===============================`);
     // Memory warnings
-    if (heapUsedPercentage > 85) {
+    const heapUsedMB = Math.round(memoryUsage.heapUsed / 1024 / 1024);
+    const heapTotalMB = Math.round(memoryUsage.heapTotal / 1024 / 1024);
+    if (heapUsedMB > 400) {
+      // Only warn if actually using 400MB+
       console.warn(`MEMORY WARNING: Heap usage at ${heapUsedPercentage}%`);
       if (heapUsedPercentage > 90) {
         console.warn(
-          "EMERGENCY MEMORY CLEANUP: Clearing large message buffers"
+          "EMERGENCY MEMORY CLEANUP: Clearing large message buffers",
         );
         for (const [userId, message] of userMessageBuffers.entries()) {
           if (message.length > 1000) {
             userMessageBuffers.set(
               userId,
               message.substring(0, 1000) +
-                "... [truncated for system stability]"
+                "... [truncated for system stability]",
             );
           }
         }
@@ -3388,7 +3505,7 @@ setInterval(() => {
       for (const [ip, count] of ipConnections.entries()) {
         if (count > CONFIG.LIMITS.MAX_CONNECTIONS_PER_IP * 0.8) {
           console.warn(
-            `IP warning: ${ip} has ${count} connections (max: ${CONFIG.LIMITS.MAX_CONNECTIONS_PER_IP})`
+            `IP warning: ${ip} has ${count} connections (max: ${CONFIG.LIMITS.MAX_CONNECTIONS_PER_IP})`,
           );
         }
       }
@@ -3397,6 +3514,57 @@ setInterval(() => {
     console.error("Error in enhanced server monitor:", err);
   }
 }, 120000); // Every 2 minutes
+
+function purgeAllGhostUsers() {
+  // At startup, there are ZERO active socket connections,
+  // so every user in every room is a ghost.
+  let totalPurged = 0;
+
+  for (const [roomId, room] of rooms) {
+    if (room.users && room.users.length > 0) {
+      console.log(
+        `Startup purge: clearing ${room.users.length} ghost(s) from room "${room.name}" (${roomId})`,
+      );
+      totalPurged += room.users.length;
+
+      // Clean up resources for each ghost user
+      for (const user of room.users) {
+        userMessageBuffers.delete(user.id);
+        clearAFKTimers(user.id);
+        if (typingTimeouts.has(user.id)) {
+          clearTimeout(typingTimeouts.get(user.id));
+          typingTimeouts.delete(user.id);
+        }
+      }
+
+      room.users = [];
+      room.votes = {};
+      room.lastActiveTime = Date.now();
+
+      // Start deletion timer for this now-empty room
+      startRoomDeletionTimer(roomId);
+    }
+  }
+
+  if (totalPurged > 0) {
+    console.log(
+      `Startup purge complete: removed ${totalPurged} total ghost user(s)`,
+    );
+    // Save the cleaned state
+    debouncedSaveRooms().catch((err) =>
+      console.error("Failed to save rooms after startup purge:", err),
+    );
+  } else {
+    console.log("Startup purge: no ghost users found");
+  }
+}
+
+// Run the purge after rooms are loaded but before accepting connections.
+// We use a short delay to ensure loadRooms() has completed.
+setTimeout(() => {
+  purgeAllGhostUsers();
+  updateLobby();
+}, 2000);
 
 // ============================================================================
 // SERVER STARTUP
@@ -3461,9 +3629,9 @@ Security Enhancements:
   // Log initial statistics
   const stats = getRoomStatistics();
   console.log(
-    `Initial state: ${stats.totalRooms}/${stats.currentLimit} rooms, ${stats.totalUsers} users`
+    `Initial state: ${stats.totalRooms}/${stats.currentLimit} rooms, ${stats.totalUsers} users`,
   );
   console.log(
-    `Bot tokens: ${botTokens.size} active, IP users: ${ipBasedUsers.size}`
+    `Bot tokens: ${botTokens.size} active, IP users: ${ipBasedUsers.size}`,
   );
 });


### PR DESCRIPTION
Clear stale socket-less users when loading rooms (reset users array and lastActiveTime) and start deletion timers for empty loaded rooms to prevent ghost users persisting across restarts. Disable IP-based users in CONFIG and add several server-side robustness fixes (safer WordFilter init, added commas, improved logging). Apply various frontend fixes and consistency changes: normalize <!doctype>, add #noRoomsMessage style, set default roomType on init, add Discord invite toast, and clean up JS formatting/quoting/trailing commas across lobby, room, and client scripts. Also add repo-tree.html to .gitignore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic cleanup of inactive users from rooms to maintain room integrity and prevent orphaned participants.

* **Chores**
  * Updated default configuration to disable IP-based anonymous user access.
  * Minor styling refinements to cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->