### PR TITLE
Preserve raw chat text when updating UI

### DIFF
--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -1442,14 +1442,28 @@ socket.on("room update", (roomData) => {
   const activeEl = document.activeElement;
   const saved = new Map();
   let savedCursor = 0;
+
+  // Save RAW text, not filtered display text
   document.querySelectorAll(".chat-row").forEach((row) => {
     const uid = row.dataset.userId;
     const ci = row.querySelector(".chat-input");
     if (ci) {
-      saved.set(uid, getPlainText(ci));
+      if (uid === currentUserId) {
+        // Use selfRawText which always has the real unfiltered text
+        saved.set(uid, selfRawText);
+      } else {
+        // Use stored raw text, fall back to display text if not available
+        saved.set(
+          uid,
+          ci.dataset.rawText !== undefined
+            ? ci.dataset.rawText
+            : getPlainText(ci),
+        );
+      }
       if (activeEl === ci) savedCursor = getCursorPosition(ci);
     }
   });
+
   const existing = new Set();
   document
     .querySelectorAll(".chat-row")
@@ -1465,14 +1479,14 @@ socket.on("room update", (roomData) => {
     if (!current.has(r.dataset.userId) && r.dataset.userId !== currentUserId)
       r.remove();
   });
-  saved.forEach((val, uid) => {
+  saved.forEach((rawVal, uid) => {
     const ci = document.querySelector(
       `.chat-row[data-user-id="${uid}"] .chat-input`,
     );
     if (!ci) return;
     if (uid === currentUserId) {
-      selfRawText = val;
-      const display = applyWordFilter(val);
+      selfRawText = rawVal;
+      const display = applyWordFilter(rawVal);
       ci.innerHTML = "";
       ci.textContent = display;
       replaceEmotes(ci);
@@ -1488,7 +1502,10 @@ socket.on("room update", (roomData) => {
           placeCursorAtEnd(ci);
         }
       }
-    } else renderOtherUserMessage(ci, val);
+    } else {
+      // Pass raw text so dataset.rawText stays correct
+      renderOtherUserMessage(ci, rawVal);
+    }
   });
   if (roomData.votes) updateVotesUI(roomData.votes);
   adjustLayout();

--- a/public/room.html
+++ b/public/room.html
@@ -520,7 +520,7 @@
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="js/word-filter-client.js?v=1.0.1"></script>
-    <script src="js/room-client.js?v=1.4.0"></script>
+    <script src="js/room-client.js?v=1.4.1"></script>
     <script src="js/games-client.js?v=1.0.3"></script>
 
     <!-- Feature announcement logic -->


### PR DESCRIPTION
When handling room updates, save and restore users' raw (unfiltered) chat text instead of the filtered/display text. Use selfRawText for the current user, and for others prefer ci.dataset.rawText with a fallback to the displayed plain text. Pass raw text into applyWordFilter and renderOtherUserMessage so datasets remain correct, and keep cursor position handling intact. Also bumped room-client.js version querystring to v=1.4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message handling during room updates to correctly preserve and synchronize messages for all users, ensuring proper display and server state consistency.

* **Chores**
  * Updated script version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->