### PR TITLE
Updated state.js so the max character limit matches the client limit

### DIFF
--- a/server/state.js
+++ b/server/state.js
@@ -17,7 +17,7 @@ const CONFIG = {
     MAX_AFK_TIME: 180000,
     MAX_LOCATION_LENGTH: 20,
     MAX_ROOM_NAME_LENGTH: 25,
-    MAX_MESSAGE_LENGTH: 15000,
+    MAX_MESSAGE_LENGTH: 5000, // to match w client and cuz ion know what type of rendering issues it was causing.
     MAX_ROOM_CAPACITY: 5,
     BASE_MAX_ROOMS: 15,
     ROOM_SCALING_INCREMENT: 5,


### PR DESCRIPTION
i dont think this will cause any issues other than some bots need to be changed slightly if they go over 5k characters, the original bug thing never said what type of rendering issues so this seems to be the easiest change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the maximum allowed chat message length to 5,000 characters. Messages exceeding this limit will be automatically truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->