### PR TITLE
add new device type, add filtering to emotes

### DIFF
--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -498,33 +498,27 @@ async function loadEmotes() {
   }
 }
 
-function parseJSONC(input) {
-  const json = stripJSONC(input);
+function parseJSONC(input, filteredTags = ["*"]) {
+  const json = stripJSONC(input, filteredTags);
   return JSON.parse(json);
 }
 
-function stripJSONC(input) {
+function stripJSONC(input, filteredTags = []) {
+  const filtered = new Set(
+    Array.isArray(filteredTags) ? filteredTags : [filteredTags]
+  );
+
   let out = "";
   let i = 0;
 
   let inString = false;
   let stringQuote = "";
   let escaped = false;
-  let inLineComment = false;
   let inBlockComment = false;
 
   while (i < input.length) {
     const ch = input[i];
     const next = input[i + 1];
-
-    if (inLineComment) {
-      if (ch === "\n") {
-        inLineComment = false;
-        out += ch;
-      }
-      i++;
-      continue;
-    }
 
     if (inBlockComment) {
       if (ch === "*" && next === "/") {
@@ -557,15 +551,36 @@ function stripJSONC(input) {
       continue;
     }
 
-    if (ch === "/" && next === "/") {
-      inLineComment = true;
+    if (ch === "/" && next === "*") {
+      inBlockComment = true;
       i += 2;
       continue;
     }
 
-    if (ch === "/" && next === "*") {
-      inBlockComment = true;
-      i += 2;
+    if (ch === "/" && next === "/") {
+      const lineStart = out.lastIndexOf("\n") + 1;
+      const lineBeforeComment = out.slice(lineStart);
+      const trimmed = lineBeforeComment.trimEnd();
+
+      const propMatch = trimmed.match(
+        /(?:^|,)\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\s*:\s*.*$/
+      );
+
+      if (propMatch) {
+        const commentText = input.slice(i + 2, input.indexOf("\n", i) === -1 ? input.length : input.indexOf("\n", i));
+        const tags = commentText
+          .split(";")
+          .map(s => s.trim())
+          .filter(Boolean);
+
+        if (tags.some(tag => filtered.has(tag))) {
+          out = out.slice(0, lineStart);
+          while (i < input.length && input[i] !== "\n") i++;
+          continue;
+        }
+      }
+
+      while (i < input.length && input[i] !== "\n") i++;
       continue;
     }
 

--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -105,7 +105,7 @@ function filterTextPreservingEmotes(text) {
     return clientWordFilter.filterText(text);
   }
 
-  const regex = /(:([\w]+):|;([\w]+);)/g;
+  const regex = /(:([A-Za-z0-9_.-]+):|;([A-Za-z0-9_.-]+);)/g;
   let result = "";
   let lastIndex = 0;
   let foundEmote = false;
@@ -643,7 +643,7 @@ function replaceEmotes(element) {
   const text = getPlainText(element);
   if (!text.includes(":") && !text.includes(";")) return;
 
-  const tokenRegex = /(:([\w]+):|;([\w]+);)/g;
+  const tokenRegex = /(:([A-Za-z0-9_.-]+):|;([A-Za-z0-9_.-]+);)/g;
   const matches = [...text.matchAll(tokenRegex)];
   if (matches.length === 0) return;
 

--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -498,7 +498,7 @@ async function loadEmotes() {
   }
 }
 
-function parseJSONC(input, filteredTags = ["*"]) {
+function parseJSONC(input, filteredTags = ["*"]) { // "*" represents unwanted, not wildcard
   const json = stripJSONC(input, filteredTags);
   return JSON.parse(json);
 }

--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -2329,6 +2329,7 @@ socket.on("dev hide status", (data) => {
 const DEVICE_META = {
   desktop: { icon: "fas fa-desktop", title: "Desktop" },
   mobile: { icon: "fas fa-mobile-screen-button", title: "Mobile" },
+  qwerty: { icon: "fas fa-tty", title: "QWERTY Phone" },
   tablet: { icon: "fas fa-tablet-screen-button", title: "Tablet" },
   tv: { icon: "fas fa-tv", title: "TV" },
   vr: { icon: "fas fa-vr-cardboard", title: "VR" },

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -128,7 +128,7 @@ function deviceTypeFromUA(ua) {
   if (/(android automotive|androidauto|carplay|tesla|mbux|sync|qtcarbrowser)/i.test(s))
     return "car";
 
-  if (/(blackberry|nokia)/i.test(s))
+  if (/(blackberry|nokia)/i.test(s) && !/android/i.test(s))
     return "qwerty";
 
   if (/(mobi|iphone|ipod|android|bb10|iemobile|opera mini|windows phone)/i.test(s))

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -105,7 +105,7 @@ function deviceTypeFromUA(ua) {
   if (/fridge|refrigerator|familyhub|family hub/i.test(s))
     return "refrigerator";
 
-  if (/(oculusbrowser|vision pro|visionos|vive|valve index|windows mixed reality|pico|vr|xr)/i.test(s))
+  if (/(oculusbrowser|vision pro|visionos|vive|valve index|windows mixed reality|pico|vr|xr|x4000)/i.test(s))
     return "vr";
 
   if (/(playstation|ps[1-5]|xbox|nintendo)/i.test(s))
@@ -117,7 +117,7 @@ function deviceTypeFromUA(ua) {
   if (/(smart-?tv|googletv|apple tv|androidtv|crkey|roku|aft[a-z]|netcast|web0s|webos|tizen|hbbtv|bravia|viera)/i.test(s))
     return "tv";
 
-  if ((/(ipad|tablet|playbook)/i.test(s) || (/android/i.test(s) && !/mobile/i.test(s))) &&
+  if ((/(ipad|tablet|playbook|portalgo)/i.test(s) || (/android/i.test(s) && !/mobile/i.test(s))) &&
     !E_READER_RE.test(s)
   ) return "tablet";
 
@@ -128,7 +128,10 @@ function deviceTypeFromUA(ua) {
   if (/(android automotive|androidauto|carplay|tesla|mbux|sync|qtcarbrowser)/i.test(s))
     return "car";
 
-  if (/(mobi|iphone|ipod|android|blackberry|bb10|iemobile|opera mini|windows phone)/i.test(s))
+  if (/(blackberry|nokia)/i.test(s))
+    return "qwerty";
+
+  if (/(mobi|iphone|ipod|android|bb10|iemobile|opera mini|windows phone)/i.test(s))
     return "mobile";
 
   if (/(windows|macintosh|mac os|linux|cros|x11)/i.test(s))


### PR DESCRIPTION
Implements:
- Adds the QWERTY Phone as a device type
- Hardens User-Agents for device types
- Adds a filtering system for emotes so I can keep emotes I want for MPP but keep out of Talko (uses a tag system)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved device identification for more accurate icons and labels in user lists.
  * Expanded support for additional emote text formats, so more emotes display correctly.

* **Bug Fixes**
  * Fixed filtering and text replacement so comments and tagged entries are handled more reliably.
  * Improved device detection for several platforms, including VR, tablet, and keyboard-based mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->