### PR TITLE
Feat. Mod user notes, Talkoboard fix, Mod kick fix, Fix user-agent icons

### DIFF
--- a/public/js/mod.js
+++ b/public/js/mod.js
@@ -104,7 +104,7 @@
     other: {
       color: "#6b7080",
       icon: "fa-circle-info",
-      label: "Other: spectate, staff login",
+      label: "Other: spectate, staff login, mod note",
     },
   };
 

--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -2519,6 +2519,14 @@ function trophyImgFor(rank) {
   return img;
 }
 
+function syncUserRowNote(row, user) {
+  if (!row || !user) return;
+  const note = typeof user.note === "string" ? user.note : "";
+  row.dataset.note = note;
+  const noteBtn = row.querySelector(".note-action-button");
+  if (noteBtn) noteBtn.classList.toggle("has-note", !!note);
+}
+
 function createUserRow(user, container) {
   const row = document.createElement("div");
   row.classList.add("chat-row");
@@ -2534,6 +2542,8 @@ function createUserRow(user, container) {
   if (user.isDev && !user.isHidden) {
     row.classList.add("dev-user");
   }
+
+  syncUserRowNote(row, user);
 
   const info = document.createElement("span");
   info.className = "user-info";
@@ -2625,13 +2635,25 @@ function createUserRow(user, container) {
     : currentUserIsMod
       ? targetVisibleRole === null
       : false;
-  if (isStaff() && user.id !== currentUserId && canActOnTarget) {
-    const staffBtn = document.createElement("button");
-    staffBtn.className = "staff-action-button";
-    staffBtn.innerHTML = '<i class="fas fa-gear"></i>'; // gear
-    staffBtn.title = "Staff actions";
-    staffBtn.addEventListener("click", () => openUserStaffMenu(user));
-    info.appendChild(staffBtn);
+  if (isStaff()) {
+    const noteBtn = document.createElement("button");
+    noteBtn.className = "staff-action-button note-action-button";
+    noteBtn.innerHTML = '<i class="fas fa-sticky-note"></i>';
+    noteBtn.title = user.id === currentUserId ? "View/edit your note" : "View/edit note";
+    noteBtn.addEventListener("click", () => {
+      const note = row.dataset.note || "";
+      openUserNoteDialog({ ...user, note }, { viewOnly: false });
+    });
+    info.appendChild(noteBtn);
+
+    if (user.id !== currentUserId && canActOnTarget) {
+      const staffBtn = document.createElement("button");
+      staffBtn.className = "staff-action-button";
+      staffBtn.innerHTML = '<i class="fas fa-gear"></i>'; // gear
+      staffBtn.title = "Staff actions";
+      staffBtn.addEventListener("click", () => openUserStaffMenu(user));
+      info.appendChild(staffBtn);
+    }
   }
   // Report flag is available to everyone (staff included) on other users' rows,
   // so anyone can flag a problem user, a bad room, or even a misbehaving mod.
@@ -3332,6 +3354,7 @@ socket.on("room update", (roomData) => {
       const row = document.querySelector(`.chat-row[data-user-id="${u.id}"]`);
       if (!row) return;
       applyDevAppearanceToRow(row, u);
+      syncUserRowNote(row, u);
     });
   }
 
@@ -3802,6 +3825,40 @@ async function openReportPrompt(user) {
     });
 }
 
+async function openUserNoteDialog(user, { viewOnly = true } = {}) {
+  const name = user.username || "user";
+  const currentNote = typeof user.note === "string" ? user.note : "";
+  if (!window.StaffUI) {
+    const msg = currentNote || "No note on file.";
+    window.alert(`Note for ${name}:\n\n${msg}`);
+    return;
+  }
+  if (viewOnly) {
+    StaffUI.alert(
+      `Note for ${name}`,
+      currentNote || "No note on file.",
+      '<i class="fas fa-sticky-note"></i>',
+    );
+    return;
+  }
+  const r = await StaffUI.prompt({
+    title: `Note for ${name}`,
+    icon: '<i class="fas fa-sticky-note"></i>',
+    fields: [
+      {
+        name: "value",
+        label: "Note message",
+        type: "textarea",
+        value: currentNote,
+        placeholder: "This user was promoting unsafe websites...",
+        maxLength: 1000,
+      },
+    ],
+    confirmText: "Save note",
+  });
+  if (r != null) socket.emit("staff note", { targetUserId: user.id, message: r });
+}
+
 // ── Per-user staff menu ──────────────────────────────────────────────────────
 function openUserStaffMenu(user) {
   if (!window.StaffUI) return;
@@ -3836,7 +3893,7 @@ function openUserStaffMenu(user) {
   if (isFullMod) {
     items.push({
       icon: '<i class="fas fa-user-slash"></i>',
-      label: "Kick + room ban",
+      label: "Kick and room ban",
       danger: true,
       desc: "Remove and ban from this room",
       onClick: async () => {
@@ -3858,7 +3915,7 @@ function openUserStaffMenu(user) {
   if (isFullMod) {
     items.push({
       icon: '<i class="fas fa-ban"></i>',
-      label: "IP block…",
+      label: "IP block...",
       danger: true,
       desc: "Block this user's IP for a set time",
       onClick: () => openIpBlockPicker(user),
@@ -3875,7 +3932,7 @@ function openUserStaffMenu(user) {
   // Warn and force rename: available to every mod level.
   items.push({
     icon: '<i class="fas fa-bullhorn"></i>',
-    label: "Warn…",
+    label: "Warn...",
     desc: "Send a private warning",
     onClick: async () => {
       const r = await StaffUI.prompt({
@@ -3886,7 +3943,7 @@ function openUserStaffMenu(user) {
             name: "value",
             label: "Warning message",
             type: "textarea",
-            placeholder: "Please follow the room rules…",
+            placeholder: "Please follow the room rules...",
             maxLength: 1000,
             required: true,
           },
@@ -3916,7 +3973,7 @@ function openUserStaffMenu(user) {
   // may mint a junior (L1) key only. The server re-checks who may grant what.
   const makeModItem = {
     icon: '<i class="fas fa-user-shield"></i>',
-    label: currentUserIsDev ? "Make this user a mod…" : "Make junior mod",
+    label: currentUserIsDev ? "Make this user a mod..." : "Make junior mod",
     desc: currentUserIsDev
       ? "Promote - choose a level"
       : "Grant a junior (level 1) mod key",
@@ -4216,7 +4273,7 @@ function openStaffPanel() {
     });
     appearanceItems.push({
       icon: '<i class="fas fa-palette"></i>',
-      label: "Custom name color…",
+      label: "Custom name color...",
       desc: "Set your chat text color",
       onClick: async () => {
         const color = await StaffUI.prompt({
@@ -4268,7 +4325,7 @@ function openStaffPanel() {
       items: [
         {
           icon: '<i class="fas fa-tower-broadcast"></i>',
-          label: "Megaphone this room…",
+          label: "Megaphone this room...",
           desc: "Announcement banner to this room",
           onClick: async () => {
             const m = await StaffUI.prompt({
@@ -4322,7 +4379,7 @@ function openStaffPanel() {
       items: [
         {
           icon: '<i class="fas fa-flag"></i>',
-          label: "Feature flags…",
+          label: "Feature flags...",
           desc: "Word filter / room creation / limit",
           onClick: () => socket.emit("dev get flags"),
         },
@@ -4494,7 +4551,7 @@ function toggleDevHud() {
   }
   hud = document.createElement("div");
   hud.id = "devHud";
-  hud.textContent = "HUD: loading…";
+  hud.textContent = "HUD: loading...";
   document.body.appendChild(hud);
   const poll = () => socket.emit("dev request hud");
   poll();
@@ -4770,7 +4827,7 @@ socket.on("staff key result", (d) => {
   else localStorage.setItem("talkomatic_modKey", pendingStaffKey);
   pendingStaffKey = null;
   notify(
-    `Key accepted. You are ${d.role}${d.label ? " (" + d.label + ")" : ""}. Reloading…`,
+    `Key accepted. You are ${d.role}${d.label ? " (" + d.label + ")" : ""}. Reloading...`,
     "success",
   );
   setTimeout(() => window.location.reload(), 1200);
@@ -4780,8 +4837,8 @@ socket.on("you are now mod", (d) => {
   localStorage.setItem("talkomatic_modKey", d.key);
   notify(
     d.level === 2
-      ? "You've been promoted to Moderator (full)! Reloading…"
-      : "You've been made a Junior Moderator! Reloading…",
+      ? "You've been promoted to Moderator (full)! Reloading..."
+      : "You've been made a Junior Moderator! Reloading...",
     "success",
     { title: "You are now a mod", timeout: 4000 },
   );

--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -3771,25 +3771,43 @@ function openUserStaffMenu(user) {
   // Kick. Full mods/devs also place a room ban; junior mods can only remove.
   items.push({
     icon: '<i class="fas fa-user-slash"></i>',
-    label: isFullMod ? "Kick + room ban" : "Kick from room",
+    label: "Kick from room",
     danger: true,
-    desc: isFullMod
-      ? "Remove and ban from this room"
-      : "Remove from this room (no ban)",
+    desc: "Remove from this room (no ban)",
     onClick: async () => {
       if (
         await StaffUI.confirm({
-          title: isFullMod ? "Kick + ban" : "Kick",
-          message: isFullMod
-            ? `Kick and room-ban ${name}?`
-            : `Remove ${name} from this room?`,
+          title: "Kick",
+          message: `Remove ${name} from this room?`,
           danger: true,
-          confirmText: isFullMod ? "Kick + ban" : "Kick",
+          confirmText: "Kick",
         })
-      )
-        socket.emit("staff kick", { targetUserId: user.id, ban: isFullMod });
+      ) {
+        socket.emit("staff kick", { targetUserId: user.id, ban: false });
+      }
     },
   });
+
+  if (isFullMod) {
+    items.push({
+      icon: '<i class="fas fa-user-slash"></i>',
+      label: "Kick + room ban",
+      danger: true,
+      desc: "Remove and ban from this room",
+      onClick: async () => {
+        if (
+          await StaffUI.confirm({
+            title: "Kick + ban",
+            message: `Kick and room-ban ${name}?`,
+            danger: true,
+            confirmText: "Kick + ban",
+          })
+        ) {
+          socket.emit("staff kick", { targetUserId: user.id, ban: true });
+        }
+      },
+    });
+  }
 
   // IP block - full mods / devs only.
   if (isFullMod) {

--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -3816,25 +3816,43 @@ function openUserStaffMenu(user) {
   // Kick. Full mods/devs also place a room ban; junior mods can only remove.
   items.push({
     icon: '<i class="fas fa-user-slash"></i>',
-    label: isFullMod ? "Kick + room ban" : "Kick from room",
+    label: "Kick from room",
     danger: true,
-    desc: isFullMod
-      ? "Remove and ban from this room"
-      : "Remove from this room (no ban)",
+    desc: "Remove from this room (no ban)",
     onClick: async () => {
       if (
         await StaffUI.confirm({
-          title: isFullMod ? "Kick + ban" : "Kick",
-          message: isFullMod
-            ? `Kick and room-ban ${name}?`
-            : `Remove ${name} from this room?`,
+          title: "Kick",
+          message: `Remove ${name} from this room?`,
           danger: true,
-          confirmText: isFullMod ? "Kick + ban" : "Kick",
+          confirmText: "Kick",
         })
-      )
-        socket.emit("staff kick", { targetUserId: user.id, ban: isFullMod });
+      ) {
+        socket.emit("staff kick", { targetUserId: user.id, ban: false });
+      }
     },
   });
+
+  if (isFullMod) {
+    items.push({
+      icon: '<i class="fas fa-user-slash"></i>',
+      label: "Kick + room ban",
+      danger: true,
+      desc: "Remove and ban from this room",
+      onClick: async () => {
+        if (
+          await StaffUI.confirm({
+            title: "Kick + ban",
+            message: `Kick and room-ban ${name}?`,
+            danger: true,
+            confirmText: "Kick + ban",
+          })
+        ) {
+          socket.emit("staff kick", { targetUserId: user.id, ban: true });
+        }
+      },
+    });
+  }
 
   // IP block - full mods / devs only.
   if (isFullMod) {

--- a/public/js/room-client.js
+++ b/public/js/room-client.js
@@ -2505,6 +2505,14 @@ function trophyImgFor(rank) {
   return img;
 }
 
+function syncUserRowNote(row, user) {
+  if (!row || !user) return;
+  const note = typeof user.note === "string" ? user.note : "";
+  row.dataset.note = note;
+  const noteBtn = row.querySelector(".note-action-button");
+  if (noteBtn) noteBtn.classList.toggle("has-note", !!note);
+}
+
 function createUserRow(user, container) {
   const row = document.createElement("div");
   row.classList.add("chat-row");
@@ -2520,6 +2528,8 @@ function createUserRow(user, container) {
   if (user.isDev && !user.isHidden) {
     row.classList.add("dev-user");
   }
+
+  syncUserRowNote(row, user);
 
   const info = document.createElement("span");
   info.className = "user-info";
@@ -2611,13 +2621,25 @@ function createUserRow(user, container) {
     : currentUserIsMod
       ? targetVisibleRole === null
       : false;
-  if (isStaff() && user.id !== currentUserId && canActOnTarget) {
-    const staffBtn = document.createElement("button");
-    staffBtn.className = "staff-action-button";
-    staffBtn.innerHTML = '<i class="fas fa-gear"></i>'; // gear
-    staffBtn.title = "Staff actions";
-    staffBtn.addEventListener("click", () => openUserStaffMenu(user));
-    info.appendChild(staffBtn);
+  if (isStaff()) {
+    const noteBtn = document.createElement("button");
+    noteBtn.className = "staff-action-button note-action-button";
+    noteBtn.innerHTML = '<i class="fas fa-sticky-note"></i>';
+    noteBtn.title = user.id === currentUserId ? "View/edit your note" : "View/edit note";
+    noteBtn.addEventListener("click", () => {
+      const note = row.dataset.note || "";
+      openUserNoteDialog({ ...user, note }, { viewOnly: false });
+    });
+    info.appendChild(noteBtn);
+
+    if (user.id !== currentUserId && canActOnTarget) {
+      const staffBtn = document.createElement("button");
+      staffBtn.className = "staff-action-button";
+      staffBtn.innerHTML = '<i class="fas fa-gear"></i>'; // gear
+      staffBtn.title = "Staff actions";
+      staffBtn.addEventListener("click", () => openUserStaffMenu(user));
+      info.appendChild(staffBtn);
+    }
   }
   // Report flag is available to everyone (staff included) on other users' rows,
   // so anyone can flag a problem user, a bad room, or even a misbehaving mod.
@@ -3291,6 +3313,7 @@ socket.on("room update", (roomData) => {
       const row = document.querySelector(`.chat-row[data-user-id="${u.id}"]`);
       if (!row) return;
       applyDevAppearanceToRow(row, u);
+      syncUserRowNote(row, u);
     });
   }
 
@@ -3757,6 +3780,40 @@ async function openReportPrompt(user) {
     });
 }
 
+async function openUserNoteDialog(user, { viewOnly = true } = {}) {
+  const name = user.username || "user";
+  const currentNote = typeof user.note === "string" ? user.note : "";
+  if (!window.StaffUI) {
+    const msg = currentNote || "No note on file.";
+    window.alert(`Note for ${name}:\n\n${msg}`);
+    return;
+  }
+  if (viewOnly) {
+    StaffUI.alert(
+      `Note for ${name}`,
+      currentNote || "No note on file.",
+      '<i class="fas fa-sticky-note"></i>',
+    );
+    return;
+  }
+  const r = await StaffUI.prompt({
+    title: `Note for ${name}`,
+    icon: '<i class="fas fa-sticky-note"></i>',
+    fields: [
+      {
+        name: "value",
+        label: "Note message",
+        type: "textarea",
+        value: currentNote,
+        placeholder: "This user was promoting unsafe websites...",
+        maxLength: 1000,
+      },
+    ],
+    confirmText: "Save note",
+  });
+  if (r != null) socket.emit("staff note", { targetUserId: user.id, message: r });
+}
+
 // ── Per-user staff menu ──────────────────────────────────────────────────────
 function openUserStaffMenu(user) {
   if (!window.StaffUI) return;
@@ -3791,7 +3848,7 @@ function openUserStaffMenu(user) {
   if (isFullMod) {
     items.push({
       icon: '<i class="fas fa-user-slash"></i>',
-      label: "Kick + room ban",
+      label: "Kick and room ban",
       danger: true,
       desc: "Remove and ban from this room",
       onClick: async () => {
@@ -3813,7 +3870,7 @@ function openUserStaffMenu(user) {
   if (isFullMod) {
     items.push({
       icon: '<i class="fas fa-ban"></i>',
-      label: "IP block…",
+      label: "IP block...",
       danger: true,
       desc: "Block this user's IP for a set time",
       onClick: () => openIpBlockPicker(user),
@@ -3830,7 +3887,7 @@ function openUserStaffMenu(user) {
   // Warn and force rename: available to every mod level.
   items.push({
     icon: '<i class="fas fa-bullhorn"></i>',
-    label: "Warn…",
+    label: "Warn...",
     desc: "Send a private warning",
     onClick: async () => {
       const r = await StaffUI.prompt({
@@ -3841,7 +3898,7 @@ function openUserStaffMenu(user) {
             name: "value",
             label: "Warning message",
             type: "textarea",
-            placeholder: "Please follow the room rules…",
+            placeholder: "Please follow the room rules...",
             maxLength: 1000,
             required: true,
           },
@@ -3871,7 +3928,7 @@ function openUserStaffMenu(user) {
   // may mint a junior (L1) key only. The server re-checks who may grant what.
   const makeModItem = {
     icon: '<i class="fas fa-user-shield"></i>',
-    label: currentUserIsDev ? "Make this user a mod…" : "Make junior mod",
+    label: currentUserIsDev ? "Make this user a mod..." : "Make junior mod",
     desc: currentUserIsDev
       ? "Promote - choose a level"
       : "Grant a junior (level 1) mod key",
@@ -4163,7 +4220,7 @@ function openStaffPanel() {
     });
     appearanceItems.push({
       icon: '<i class="fas fa-palette"></i>',
-      label: "Custom name color…",
+      label: "Custom name color...",
       desc: "Set your chat text color",
       onClick: async () => {
         const color = await StaffUI.prompt({
@@ -4215,7 +4272,7 @@ function openStaffPanel() {
       items: [
         {
           icon: '<i class="fas fa-tower-broadcast"></i>',
-          label: "Megaphone this room…",
+          label: "Megaphone this room...",
           desc: "Announcement banner to this room",
           onClick: async () => {
             const m = await StaffUI.prompt({
@@ -4269,7 +4326,7 @@ function openStaffPanel() {
       items: [
         {
           icon: '<i class="fas fa-flag"></i>',
-          label: "Feature flags…",
+          label: "Feature flags...",
           desc: "Word filter / room creation / limit",
           onClick: () => socket.emit("dev get flags"),
         },
@@ -4441,7 +4498,7 @@ function toggleDevHud() {
   }
   hud = document.createElement("div");
   hud.id = "devHud";
-  hud.textContent = "HUD: loading…";
+  hud.textContent = "HUD: loading...";
   document.body.appendChild(hud);
   const poll = () => socket.emit("dev request hud");
   poll();
@@ -4713,7 +4770,7 @@ socket.on("staff key result", (d) => {
   else localStorage.setItem("talkomatic_modKey", pendingStaffKey);
   pendingStaffKey = null;
   notify(
-    `Key accepted. You are ${d.role}${d.label ? " (" + d.label + ")" : ""}. Reloading…`,
+    `Key accepted. You are ${d.role}${d.label ? " (" + d.label + ")" : ""}. Reloading...`,
     "success",
   );
   setTimeout(() => window.location.reload(), 1200);
@@ -4723,8 +4780,8 @@ socket.on("you are now mod", (d) => {
   localStorage.setItem("talkomatic_modKey", d.key);
   notify(
     d.level === 2
-      ? "You've been promoted to Moderator (full)! Reloading…"
-      : "You've been made a Junior Moderator! Reloading…",
+      ? "You've been promoted to Moderator (full)! Reloading..."
+      : "You've been made a Junior Moderator! Reloading...",
     "success",
     { title: "You are now a mod", timeout: 4000 },
   );

--- a/public/mod.html
+++ b/public/mod.html
@@ -2289,6 +2289,6 @@
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="js/staff-ui.js?v=1.5.4"></script>
-    <script src="js/mod.js?v=3.9.2"></script>
+    <script src="js/mod.js?v=3.9.3"></script>
   </body>
 </html>

--- a/public/mod.html
+++ b/public/mod.html
@@ -2289,6 +2289,6 @@
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="js/staff-ui.js?v=1.5.2"></script>
-    <script src="js/mod.js?v=3.9.2"></script>
+    <script src="js/mod.js?v=3.9.3"></script>
   </body>
 </html>

--- a/public/mod.html
+++ b/public/mod.html
@@ -2288,7 +2288,7 @@
     </div>
 
     <script src="/socket.io/socket.io.js"></script>
-    <script src="js/staff-ui.js?v=1.5.2"></script>
+    <script src="js/staff-ui.js?v=1.5.5"></script>
     <script src="js/mod.js?v=3.9.3"></script>
   </body>
 </html>

--- a/public/room.html
+++ b/public/room.html
@@ -12,7 +12,7 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <link rel="stylesheet" href="stylesheets/room.css?v=2.5.8" />
+    <link rel="stylesheet" href="stylesheets/room.css?v=2.5.9" />
     <link rel="icon" type="image/png" href="images/icons/favicon.png" />
     <style>
       /* Emote system */
@@ -418,8 +418,8 @@
       .feature-announce-btn:active {
         transform: translateY(0);
       }
-
-      .fa-gear {
+  
+      .user-info button.staff-action-button i.fas {
         color: rgb(201, 201, 201) !important;
       }
     </style>
@@ -561,7 +561,7 @@
     <script src="js/word-filter-client.js?v=2.1.3"></script>
     <script src="js/identity.js?v=1.0.2"></script>
     <script src="js/connection-overlay.js?v=1.1.2"></script>
-    <script src="js/room-client.js?v=3.11.9"></script>
+    <script src="js/room-client.js?v=3.12.1"></script>
     <script src="js/talkoboard.js?v=1.6.4"></script>
     <script src="js/piano-client.js?v=2.1.13"></script>
 

--- a/public/room.html
+++ b/public/room.html
@@ -561,7 +561,7 @@
     <script src="js/word-filter-client.js?v=2.1.3"></script>
     <script src="js/identity.js?v=1.0.2"></script>
     <script src="js/connection-overlay.js?v=1.1.2"></script>
-    <script src="js/room-client.js?v=3.11.8"></script>
+    <script src="js/room-client.js?v=3.11.10"></script>
     <script src="js/talkoboard.js?v=1.6.4"></script>
     <script src="js/piano-client.js?v=2.1.13"></script>
 

--- a/public/room.html
+++ b/public/room.html
@@ -12,7 +12,7 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <link rel="stylesheet" href="stylesheets/room.css?v=2.5.8" />
+    <link rel="stylesheet" href="stylesheets/room.css?v=2.5.9" />
     <link rel="icon" type="image/png" href="images/icons/favicon.png" />
     <style>
       /* Emote system */
@@ -418,8 +418,8 @@
       .feature-announce-btn:active {
         transform: translateY(0);
       }
-
-      .fa-gear {
+  
+      .user-info button.staff-action-button i.fas {
         color: rgb(201, 201, 201) !important;
       }
     </style>
@@ -561,7 +561,7 @@
     <script src="js/word-filter-client.js?v=2.1.3"></script>
     <script src="js/identity.js?v=1.0.2"></script>
     <script src="js/connection-overlay.js?v=1.1.2"></script>
-    <script src="js/room-client.js?v=3.11.8"></script>
+    <script src="js/room-client.js?v=3.12.0"></script>
     <script src="js/talkoboard.js?v=1.6.4"></script>
     <script src="js/piano-client.js?v=2.1.13"></script>
 

--- a/public/stylesheets/room.css
+++ b/public/stylesheets/room.css
@@ -543,6 +543,14 @@ html {
     font-size: 12px;
     margin-left: 2px;
   }
+  .user-info .note-action-button.has-note {
+    color: #ffb74d;
+    opacity: 1;
+  }
+  .user-info .staff-note-button {
+    font-size: 12px;
+    margin-left: 2px;
+  }
   .user-info .mod-badge {
     font-size: 8px;
     padding: 1px 4px;

--- a/server/identity.js
+++ b/server/identity.js
@@ -86,6 +86,7 @@ function rec(id) {
       ips: {},
       name: null,
       loc: null,
+      note: null,
     };
   }
   return r;
@@ -153,6 +154,24 @@ function setName(id, name, loc) {
   if (loc) r.loc = String(loc).slice(0, 30);
   r.last = Date.now();
   saveSoon();
+}
+
+function setNote(id, note) {
+  if (!validId(id)) return false;
+  const r = rec(id);
+  const text = typeof note === "string" ? note.trim() : "";
+  const next = text ? text.slice(0, 1000) : null;
+  if (r.note === next) return false;
+  r.note = next;
+  r.last = Date.now();
+  saveSoon();
+  return true;
+}
+
+function getNote(id) {
+  if (!validId(id)) return null;
+  const r = store[id];
+  return r && typeof r.note === "string" && r.note ? r.note : null;
 }
 
 function isActive(id) {
@@ -231,6 +250,8 @@ module.exports = {
   addTime,
   tick,
   setName,
+  setNote,
+  getNote,
   isActive,
   summary,
   getRecord,

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -560,6 +560,14 @@ function canActOn(actorSocket, targetUserId) {
   return false;
 }
 
+function canManageNotesOn(actorSocket, targetUserId) {
+  if (!actorSocket) return false;
+  if (actorSocket.isDev) return true;
+  if (!actorSocket.isMod || (actorSocket.modLevel || 2) < 1) return false;
+  const targetRole = getUserStaffRole(targetUserId);
+  return targetRole === null || targetRole === "mod";
+}
+
 // Gate helpers: emit a uniform error and return false when not permitted.
 function requireStaff(socket) {
   if (isStaffSocket(socket)) return true;
@@ -1147,6 +1155,11 @@ function formatUserForSocket(user, recipientSocket) {
   const recipientIsDev = !!recipientSocket?.isDev;
   if (user.isHidden && !recipientIsDev) {
     return formatted;
+  }
+
+  if (recipientSocket?.isDev || recipientSocket?.isMod) {
+    const note = user.deviceId ? identity.getNote(user.deviceId) : null;
+    if (note) formatted.note = note;
   }
 
   if (user.isDev) {
@@ -4054,6 +4067,53 @@ function registerSocketHandlers() {
           action: "warn",
           ok: true,
           targetUserId,
+        });
+      }),
+    );
+
+    socket.on(
+      "staff note",
+      safe(async (data) => {
+        if (!requireStaff(socket)) return;
+        const targetUserId = data?.targetUserId;
+        if (!targetUserId)
+          return socket.emit(
+            "error",
+            createErrorResponse(
+              ERROR_CODES.BAD_REQUEST,
+              "targetUserId required.",
+            ),
+          );
+        if (!canManageNotesOn(socket, targetUserId))
+          return socket.emit(
+            "error",
+            createErrorResponse(
+              ERROR_CODES.FORBIDDEN,
+              "You cannot manage notes for this user.",
+            ),
+          );
+        const roomId = getUserCurrentRoom(targetUserId);
+        const room = roomId ? state.rooms.get(roomId) : null;
+        const targetUser = room?.users.find((u) => u.id === targetUserId);
+        const targetSocket = findSocketByUserId(targetUserId, roomId);
+        const targetDeviceId = targetSocket?.deviceId || targetUser?.deviceId || null;
+        const note = sanitizeMessage(
+          typeof data?.message === "string" ? data.message : "",
+        ).slice(0, 1000);
+        if (targetDeviceId) identity.setNote(targetDeviceId, note);
+        if (roomId) updateRoom(roomId);
+        logStaff(
+          socket,
+          note ? "set note" : "clear note",
+          targetUser || { id: targetUserId },
+          room || "-",
+          note || "(cleared)",
+        );
+        socket.emit("staff action result", {
+          action: note ? "set note" : "clear note",
+          ok: true,
+          targetUserId,
+          note: note || null,
         });
       }),
     );

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -128,10 +128,10 @@ function deviceTypeFromUA(ua) {
   if (/(android automotive|androidauto|carplay|tesla|mbux|sync|qtcarbrowser)/i.test(s))
     return "car";
 
-  if (/(blackberry|nokia)/i.test(s) && !/android/i.test(s))
+  if (/(blackberry|bb10|nokia)/i.test(s) && !/android/i.test(s))
     return "qwerty";
 
-  if (/(mobi|iphone|ipod|android|bb10|iemobile|opera mini|windows phone)/i.test(s))
+  if (/(mobi|iphone|ipod|android|blackberry|bb10|nokia|iemobile|opera mini|windows phone)/i.test(s))
     return "mobile";
 
   if (/(windows|macintosh|mac os|linux|cros|x11)/i.test(s))

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -179,8 +179,8 @@ loadAnniversary();
 // ── Talkoboard: Server-Side Stroke Storage (ephemeral) ──────────────────────
 
 const boardState = new Map(); // roomId → { strokes: [], active: Map<userId, stroke> }
-const MAX_BOARD_STROKES = 500;
-const MAX_POINTS_PER_STROKE = 10000;
+const MAX_BOARD_STROKES = 2000;
+const MAX_POINTS_PER_STROKE = 5000;
 
 function getBoardState(roomId) {
   if (!boardState.has(roomId)) {

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -151,8 +151,8 @@ function io() {
 // ── Talkoboard: Server-Side Stroke Storage (ephemeral) ──────────────────────
 
 const boardState = new Map(); // roomId → { strokes: [], active: Map<userId, stroke> }
-const MAX_BOARD_STROKES = 500;
-const MAX_POINTS_PER_STROKE = 10000;
+const MAX_BOARD_STROKES = 2000;
+const MAX_POINTS_PER_STROKE = 5000;
 
 function getBoardState(roomId) {
   if (!boardState.has(roomId)) {

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -129,10 +129,10 @@ function deviceTypeFromUA(ua) {
   if (/(android automotive|androidauto|carplay|tesla|mbux|sync|qtcarbrowser)/i.test(s))
     return "car";
 
-  if (/(blackberry|nokia)/i.test(s) && !/android/i.test(s))
+  if (/(blackberry|bb10|nokia)/i.test(s) && !/android/i.test(s))
     return "qwerty";
 
-  if (/(mobi|iphone|ipod|android|bb10|iemobile|opera mini|windows phone)/i.test(s))
+  if (/(mobi|iphone|ipod|android|blackberry|bb10|nokia|iemobile|opera mini|windows phone)/i.test(s))
     return "mobile";
 
   if (/(windows|macintosh|mac os|linux|cros|x11)/i.test(s))

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -114,7 +114,7 @@ function deviceTypeFromUA(ua) {
   if (/(watchos|apple watch|wear os|wearos|galaxy watch|tizen watch|smartwatch)/i.test(s))
     return "watch";
 
-  if (/(smart-?tv|googletv|apple tv|androidtv|crkey|roku|aft[a-z]|netcast|web0s|webos|tizen|hbbtv|bravia|viera)/i.test(s))
+  if (/(smart-?tv|googletv|apple tv|tv safari|androidtv|crkey|roku|aft[a-z]|netcast|web0s|webos|tizen|hbbtv|bravia|viera)/i.test(s))
     return "tv";
 
   if ((/(ipad|tablet|playbook|portalgo)/i.test(s) || (/android/i.test(s) && !/mobile/i.test(s))) &&

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -115,7 +115,7 @@ function deviceTypeFromUA(ua) {
   if (/(watchos|apple watch|wear os|wearos|galaxy watch|tizen watch|smartwatch)/i.test(s))
     return "watch";
 
-  if (/(smart-?tv|googletv|apple tv|androidtv|crkey|roku|aft[a-z]|netcast|web0s|webos|tizen|hbbtv|bravia|viera)/i.test(s))
+  if (/(smart-?tv|googletv|apple tv|tv safari|androidtv|crkey|roku|aft[a-z]|netcast|web0s|webos|tizen|hbbtv|bravia|viera)/i.test(s))
     return "tv";
 
   if ((/(ipad|tablet|playbook|portalgo)/i.test(s) || (/android/i.test(s) && !/mobile/i.test(s))) &&

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -588,6 +588,14 @@ function canActOn(actorSocket, targetUserId) {
   return false;
 }
 
+function canManageNotesOn(actorSocket, targetUserId) {
+  if (!actorSocket) return false;
+  if (actorSocket.isDev) return true;
+  if (!actorSocket.isMod || (actorSocket.modLevel || 2) < 1) return false;
+  const targetRole = getUserStaffRole(targetUserId);
+  return targetRole === null || targetRole === "mod";
+}
+
 // Gate helpers: emit a uniform error and return false when not permitted.
 function requireStaff(socket) {
   if (isStaffSocket(socket)) return true;
@@ -1178,6 +1186,11 @@ function formatUserForSocket(user, recipientSocket) {
   const recipientIsDev = !!recipientSocket?.isDev;
   if (user.isHidden && !recipientIsDev) {
     return formatted;
+  }
+
+  if (recipientSocket?.isDev || recipientSocket?.isMod) {
+    const note = user.deviceId ? identity.getNote(user.deviceId) : null;
+    if (note) formatted.note = note;
   }
 
   if (user.isDev) {
@@ -4055,6 +4068,53 @@ function registerSocketHandlers() {
           action: "warn",
           ok: true,
           targetUserId,
+        });
+      }),
+    );
+
+    socket.on(
+      "staff note",
+      safe(async (data) => {
+        if (!requireStaff(socket)) return;
+        const targetUserId = data?.targetUserId;
+        if (!targetUserId)
+          return socket.emit(
+            "error",
+            createErrorResponse(
+              ERROR_CODES.BAD_REQUEST,
+              "targetUserId required.",
+            ),
+          );
+        if (!canManageNotesOn(socket, targetUserId))
+          return socket.emit(
+            "error",
+            createErrorResponse(
+              ERROR_CODES.FORBIDDEN,
+              "You cannot manage notes for this user.",
+            ),
+          );
+        const roomId = getUserCurrentRoom(targetUserId);
+        const room = roomId ? state.rooms.get(roomId) : null;
+        const targetUser = room?.users.find((u) => u.id === targetUserId);
+        const targetSocket = findSocketByUserId(targetUserId, roomId);
+        const targetDeviceId = targetSocket?.deviceId || targetUser?.deviceId || null;
+        const note = sanitizeMessage(
+          typeof data?.message === "string" ? data.message : "",
+        ).slice(0, 1000);
+        if (targetDeviceId) identity.setNote(targetDeviceId, note);
+        if (roomId) updateRoom(roomId);
+        logStaff(
+          socket,
+          note ? "set note" : "clear note",
+          targetUser || { id: targetUserId },
+          room || "-",
+          note || "(cleared)",
+        );
+        socket.emit("staff action result", {
+          action: note ? "set note" : "clear note",
+          ok: true,
+          targetUserId,
+          note: note || null,
         });
       }),
     );


### PR DESCRIPTION
Implements:
- QWERTY Phone User-Agent detection fix
- Kick + ban seperated into Kick and Kick + ban so that L2+ mods can kick rather than force ban from room
- Feature mod notes: Allows mods to add notes to users for review and flags. (suggested by Dax)
- Modifies Talkoboard limits from 500->2000 lines and 10000->5000 points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Staff can add, view, edit, or clear notes on individual users in the room interface.
  - Saved staff notes appear for authorized moderation and development staff.
  - Note indicators now highlight users with existing notes.

- **Improvements**
  - Updated the moderation dashboard’s “Other” category to include “mod note.”
  - Improved device-type recognition and adjusted Talkoboard drawing limits.
  - Refined mobile styling and staff action icons for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->