### PR TITLE
Clear reports on action, widen mod card boards to one column

### DIFF
--- a/public/js/mod.js
+++ b/public/js/mod.js
@@ -2185,28 +2185,18 @@
     });
   }
 
-  // How a handled card announces what was done to the reported user.
-  const RESOLVE_META = {
-    warned: { icon: "fa-triangle-exclamation", label: "Warned" },
-    "ip blocked": { icon: "fa-ban", label: "IP blocked" },
-    kicked: { icon: "fa-door-open", label: "Kicked" },
-  };
   function renderReports() {
     const wrap = $("reportsList");
     if (!wrap) return;
     wrap.textContent = "";
-    const open = reportsList.filter((x) => !x.resolution).length;
-    const handled = reportsList.length - open;
     const badge = $("reportsBadge");
-    if (badge) badge.textContent = String(open);
+    if (badge) badge.textContent = String(reportsList.length);
     const sub = $("reportsSub");
     if (sub)
       sub.textContent = reportsList.length
-        ? open
-          ? open +
-            " needing action" +
-            (handled ? ", " + handled + " handled" : "")
-          : "All " + handled + " handled"
+        ? reportsList.length +
+          " reported user" +
+          (reportsList.length === 1 ? "" : "s")
         : "No reports yet";
     if (!reportsList.length) {
       const empty = document.createElement("div");
@@ -2220,10 +2210,7 @@
     reportsList.forEach((r) => {
       const hot = r.distinct >= 3;
       const card = document.createElement("div");
-      card.className =
-        "report-card" +
-        (hot ? " hot" : "") +
-        (r.resolution ? " resolved" : "");
+      card.className = "report-card" + (hot ? " hot" : "");
 
       // Header: avatar, name, reporter count, status, last-report time
       const head = document.createElement("div");
@@ -2282,25 +2269,6 @@
       }
       head.appendChild(idCol);
       card.appendChild(head);
-
-      // Action-taken banner, so nobody re-handles (or misses) a dealt-with
-      // report. Discard still removes the card entirely.
-      if (r.resolution) {
-        const rm = RESOLVE_META[r.resolution.action] || {
-          icon: "fa-check",
-          label: r.resolution.action,
-        };
-        const res = divc("rc-resolved");
-        res.appendChild(icon(rm.icon));
-        let txt = " " + rm.label;
-        if (r.resolution.action === "ip blocked" && r.resolution.duration)
-          txt += " " + durationLabel(r.resolution.duration);
-        txt += " by " + (r.resolution.by || "staff");
-        res.appendChild(document.createTextNode(txt));
-        if (r.resolution.at)
-          res.appendChild(span("when", relTime(r.resolution.at)));
-        card.appendChild(res);
-      }
 
       // Category summary tags, most-used first
       const catEntries = Object.entries(r.categories || {}).sort(

--- a/public/pages/mod.html
+++ b/public/pages/mod.html
@@ -473,11 +473,13 @@
         color: #000;
       }
 
-      /* ── Column grids: 3 → 2 → 1 ──
-         Cards keep their natural height. Stretching them to match the tallest
-         card in the row turns one big card (a person with 29 blocks) into a
-         row of empty black bars, so instead the content that can run long is
-         capped below and every card stays a comparable size. */
+      /* ── Column grids ──
+         .grid3 (activity feed, roster, sessions) stays multi-column with
+         uniform fixed-height cards: those are skim-and-move-on lists.
+         .grid2 (reports, invites, applications, appeals, suggestions) is ONE
+         column of naturally-sized cards. Staff read these top to bottom and
+         act on them, so nothing inside is clipped or scrolled away - two
+         narrow columns of inner scrollbars made them unreadable. */
       .grid3,
       .grid2 {
         display: grid;
@@ -488,15 +490,12 @@
       .grid2 > * {
         min-width: 0;
       }
-      /* Every card in a grid is the SAME height, whatever it holds, so rows
-         line up instead of ending raggedly. The card is a flex column: header
-         and footer keep their size, the middle scrolls when the content does
-         not fit. Matching the tallest card in each row was tried first and was
+      /* Every .grid3 card is the SAME height, whatever it holds, so rows line
+         up instead of ending raggedly. The card is a flex column: header and
+         footer keep their size, the middle scrolls when the content does not
+         fit. Matching the tallest card in each row was tried first and was
          worse, because one big card inflated everything beside it. */
       .grid3 > .entry,
-      .grid2 > .appcard,
-      .grid2 > .appealcard,
-      .grid2 > .report-card,
       .grid3 > .modcard,
       .grid3 > .sesscard {
         display: flex;
@@ -506,52 +505,28 @@
       .grid3 > .entry {
         height: 236px;
       }
-      .grid2 > .appcard,
-      .grid2 > .appealcard {
-        height: 320px;
-      }
-      .grid2 > .report-card {
-        height: 420px;
-      }
       .grid3 > .modcard {
         height: 232px;
       }
       .grid3 > .sesscard {
         height: 210px;
       }
-      /* The scrolling middle of each card type */
+      /* The scrolling middle of each .grid3 card type */
       .entry .e-body,
-      .appcard .ac-qa,
-      .appealcard .ap-grid,
       .modcard .mc-grid,
       .sesscard .sess-nets {
         flex: 1;
         min-height: 0;
         overflow-y: auto;
       }
-      .report-card .report-log {
-        flex: 1;
-        min-height: 0;
-        max-height: none;
-      }
       /* Footers stay put at the bottom of the card */
       .entry .cmtbox,
-      .appcard .ac-foot,
-      .appealcard .ap-foot,
-      .report-card .rc-foot,
       .modcard .mc-actions {
         flex: none;
         margin-top: auto;
       }
       .entry .e-top,
       .entry .detail,
-      .appcard .ac-head,
-      .appealcard .ap-head,
-      .report-card .rc-head,
-      .report-card .rc-resolved,
-      .report-card .rc-cats,
-      .report-card .rc-typed,
-      .report-card .report-log-head,
       .modcard .mc-top,
       .sesscard .sess-top {
         flex: none;
@@ -560,15 +535,6 @@
          rest of the card out of view. */
       .entry .detail {
         max-height: 96px;
-        overflow-y: auto;
-      }
-      .qa-a,
-      .ap-box .val {
-        max-height: 140px;
-        overflow-y: auto;
-      }
-      .rc-typed .txt {
-        max-height: 72px;
         overflow-y: auto;
       }
       /* Thin scrollbars so the inner scroll areas stay unobtrusive */
@@ -589,7 +555,7 @@
         grid-template-columns: repeat(3, minmax(0, 1fr));
       }
       .grid2 {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: minmax(0, 1fr);
       }
       @media (max-width: 1150px) {
         .grid3 {
@@ -597,8 +563,7 @@
         }
       }
       @media (max-width: 760px) {
-        .grid3,
-        .grid2 {
+        .grid3 {
           grid-template-columns: minmax(0, 1fr);
         }
       }
@@ -952,31 +917,6 @@
       .report-card.hot {
         border-color: var(--red);
       }
-      /* A handled card: dimmed, with a green "warned / blocked by X" strip */
-      .report-card.resolved {
-        opacity: 0.72;
-      }
-      .report-card.resolved:hover {
-        opacity: 1;
-      }
-      .rc-resolved {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        padding: 9px 17px;
-        border-top: 1px solid var(--line-soft);
-        background: rgba(87, 217, 163, 0.07);
-        color: var(--green);
-        font-weight: bold;
-        font-size: 13px;
-      }
-      .rc-resolved .when {
-        margin-left: auto;
-        color: var(--dim2);
-        font-weight: normal;
-        font-size: 12px;
-        white-space: nowrap;
-      }
       .rc-head {
         display: flex;
         align-items: center;
@@ -1079,10 +1019,6 @@
         letter-spacing: 0.6px;
         text-transform: uppercase;
         color: var(--dim2);
-      }
-      .report-log {
-        max-height: 360px;
-        overflow-y: auto;
       }
       .rlog {
         display: flex;

--- a/server/reports.js
+++ b/server/reports.js
@@ -24,7 +24,6 @@ const MAX_TARGETS = 5000;
 const MAX_PER_TARGET = 100;
 
 let byTarget = new Map(); // targetKey -> [{ byDeviceId, byName, category, reason, at, targetIp, targetDeviceId, targetRole, targetText }]
-let resolutions = new Map(); // targetKey -> { action, by, duration, at } once staff acted
 let saveTimer = null;
 let dirty = false;
 
@@ -33,33 +32,15 @@ function load() {
     const raw = fs.readFileSync(STORE_PATH, "utf8");
     const obj = JSON.parse(raw);
     byTarget = new Map();
-    resolutions = new Map();
     if (obj && typeof obj === "object") {
-      // v2 wraps everything in { targets, resolutions }; v1 was a bare
-      // targetKey -> array object, so fall back to reading the root.
-      const targets =
-        obj.targets && typeof obj.targets === "object" && !Array.isArray(obj.targets)
-          ? obj.targets
-          : obj;
-      for (const [k, arr] of Object.entries(targets))
+      for (const [k, arr] of Object.entries(obj))
         if (Array.isArray(arr)) byTarget.set(k, arr);
-      if (obj.resolutions && typeof obj.resolutions === "object")
-        for (const [k, r] of Object.entries(obj.resolutions))
-          if (r && typeof r === "object" && byTarget.has(k)) resolutions.set(k, r);
     }
     prune(Date.now());
   } catch (err) {
     if (err.code !== "ENOENT") console.error("Error loading reports.json:", err);
     byTarget = new Map();
-    resolutions = new Map();
   }
-}
-
-function serialize() {
-  return JSON.stringify({
-    targets: Object.fromEntries(byTarget),
-    resolutions: Object.fromEntries(resolutions),
-  });
 }
 
 // Atomic write (tmp + rename), debounced, mirrors the other JSON stores.
@@ -72,7 +53,7 @@ function saveSoon() {
     dirty = false;
     try {
       const tmp = STORE_PATH + ".tmp";
-      await fsp.writeFile(tmp, serialize(), "utf8");
+      await fsp.writeFile(tmp, JSON.stringify(Object.fromEntries(byTarget)), "utf8");
       await fsp.rename(tmp, STORE_PATH);
     } catch (e) {
       console.error("reports save failed:", e);
@@ -85,7 +66,7 @@ function saveSoon() {
 function flushSync() {
   try {
     const tmp = STORE_PATH + ".tmp";
-    fs.writeFileSync(tmp, serialize(), "utf8");
+    fs.writeFileSync(tmp, JSON.stringify(Object.fromEntries(byTarget)), "utf8");
     fs.renameSync(tmp, STORE_PATH);
   } catch (e) {
     console.error("reports flush failed:", e);
@@ -102,7 +83,6 @@ function prune(now) {
     const keys = [...byTarget.keys()];
     for (let i = 0; i < keys.length - MAX_TARGETS; i++) byTarget.delete(keys[i]);
   }
-  for (const k of resolutions.keys()) if (!byTarget.has(k)) resolutions.delete(k);
 }
 
 function distinctReporters(list) {
@@ -150,8 +130,6 @@ function add({
     targetText: targetText || null,
   });
   if (arr.length > MAX_PER_TARGET) arr.splice(0, arr.length - MAX_PER_TARGET);
-  // A fresh report reopens a handled case, so the card shows as active again.
-  resolutions.delete(targetKey);
   prune(now);
   saveSoon();
   const list = byTarget.get(targetKey) || [];
@@ -186,23 +164,8 @@ function lastKnown(targetKey) {
 // Drop every report against one target (staff discarded it as false/handled).
 function clear(targetKey) {
   const had = byTarget.delete(targetKey);
-  resolutions.delete(targetKey);
   if (had) saveSoon();
   return had;
-}
-
-// Stamp a target's reports as handled (warned / ip blocked / kicked), so the
-// board shows who took action instead of leaving the card looking untouched.
-function resolve(targetKey, { action, by, duration } = {}) {
-  if (!targetKey || !action || !byTarget.has(targetKey)) return false;
-  resolutions.set(targetKey, {
-    action,
-    by: by || null,
-    duration: duration || null,
-    at: Date.now(),
-  });
-  saveSoon();
-  return true;
 }
 
 // Compact per-target summary, most-reported first (for a dashboard view).
@@ -219,7 +182,6 @@ function summary() {
       categories: cats,
       first: arr.length ? arr[0].at : 0,
       last: arr.length ? arr[arr.length - 1].at : 0,
-      resolution: resolutions.get(targetKey) || null,
     });
   }
   return out.sort((a, b) => b.distinct - a.distinct || b.total - a.total);
@@ -238,7 +200,6 @@ module.exports = {
   lastKnown,
   summary,
   clear,
-  resolve,
   isTarget,
   flushSync,
 };

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -683,7 +683,7 @@ function resolveOfflineTarget(targetUserId) {
 // For offline users we flag whether the server still has an IP on file, so the
 // board can offer an IP block without ever sending the address to the client.
 function buildReportsList(forDev) {
-  const rows = reports.summary().map((s) => {
+  return reports.summary().map((s) => {
     const targets = findSocketsByUserId(s.targetKey);
     const online = targets.length > 0;
     let name = s.name;
@@ -721,9 +721,6 @@ function buildReportsList(forDev) {
       canBanOffline,
       first: s.first,
       last: s.last,
-      // Set once staff warned / blocked / kicked them, so the board can show
-      // "warned by X" instead of leaving the card looking untouched.
-      resolution: s.resolution || null,
       reasons: reports
         .forTarget(s.targetKey)
         .reverse()
@@ -739,10 +736,6 @@ function buildReportsList(forDev) {
         })),
     };
   });
-  // Handled cards sink below the ones still needing action; the stable sort
-  // keeps most-reported-first order within each group.
-  rows.sort((a, b) => (a.resolution ? 1 : 0) - (b.resolution ? 1 : 0));
-  return rows;
 }
 
 // Build the appeals board payload (shared by the get + resolve handlers): one
@@ -972,6 +965,18 @@ function broadcastReportsList() {
   for (const [, s] of io().sockets.sockets)
     if (s.isModLog && (s.isDev || (s.isMod && (s.modLevel || 2) >= 2)))
       s.emit("staff reports", buildReportsList(!!s.isDev));
+}
+
+// Acting on a reported user (warn / kick / ip block) settles their report, so
+// drop it from the board - the queue should only ever show what still needs
+// attention. Nothing is lost: the action itself is in the audit feed, which is
+// the permanent record.
+function clearReportAfterAction(socket, targetUserId) {
+  if (!targetUserId || !reports.clear(targetUserId)) return;
+  broadcastReportsList();
+  // Junior (L1) mods can warn and kick but sit outside the broadcast gate
+  // above, so tell the acting staffer directly too.
+  socket.emit("staff reports", buildReportsList(!!socket.isDev));
 }
 
 // Push the IP ban list to every open dashboard (full mods + devs). Each socket
@@ -3999,17 +4004,7 @@ function registerSocketHandlers() {
           ban,
           roomId,
         });
-        // Stamp their report card (if any) as handled so the board shows the
-        // kick instead of leaving the card looking untouched.
-        if (
-          reports.resolve(targetUserId, {
-            action: "kicked",
-            by: socket.staffLabel || null,
-          })
-        ) {
-          broadcastReportsList();
-          socket.emit("staff reports", buildReportsList(!!socket.isDev));
-        }
+        clearReportAfterAction(socket, targetUserId);
       }),
     );
 
@@ -4165,7 +4160,10 @@ function registerSocketHandlers() {
         logStaff(
           socket,
           `ip block ${duration}${cidr ? " (range)" : ""}`,
-          targetUser || { id: targetUserId },
+          // blockedName covers the offline case, where there is no live
+          // targetUser to read a username from. Acting clears their report, so
+          // this audit line is the only lasting record of who was blocked.
+          targetUser || { id: targetUserId, name: blockedName },
           room || "-",
           reason || undefined,
         );
@@ -4178,18 +4176,7 @@ function registerSocketHandlers() {
           // range ban only lands for IPv6, so this confirms it for them.
           rangeApplied: !!cidr,
         });
-        // Stamp their report card (if any) as handled so the board shows the
-        // block instead of leaving the card looking untouched.
-        if (
-          reports.resolve(targetUserId, {
-            action: "ip blocked",
-            by: socket.staffLabel || null,
-            duration,
-          })
-        ) {
-          broadcastReportsList();
-          socket.emit("staff reports", buildReportsList(!!socket.isDev));
-        }
+        clearReportAfterAction(socket, targetUserId);
       }),
     );
 
@@ -6662,18 +6649,7 @@ function registerSocketHandlers() {
             ? "warned " + targetName
             : "warning queued for " + targetName,
         });
-        // If they are on the reports board, stamp the card as handled so
-        // every dashboard sees action was taken (direct emit covers junior
-        // mods, who are outside the broadcast gate).
-        if (
-          reports.resolve(targetUserId, {
-            action: "warned",
-            by: socket.staffLabel || null,
-          })
-        ) {
-          broadcastReportsList();
-          socket.emit("staff reports", buildReportsList(!!socket.isDev));
-        }
+        clearReportAfterAction(socket, targetUserId);
       }),
     );
 


### PR DESCRIPTION
## What

Two fixes to the moderation dashboard.

**Acting on a report removes it.** Warn, kick, and IP block now clear the reported user from the Reports board. Before, the card stayed put after an action, so there was no way to tell an IP block had actually landed and the same person kept getting handled twice. Discard is unchanged. Nothing is lost: the action is written to the audit feed, which is the permanent record.

This replaces the "handled by X" banner from 7a01ac6 with outright removal, which is what was actually wanted. `server/reports.js` and `public/js/mod.js` are byte-identical to their pre-7a01ac6 state; the net change is only in `server/rooms.js` and `public/pages/mod.html`.

**Card boards are readable again.** Reports, invites, applications, appeals, and suggestions go from two columns to one, and cards size to their content instead of being pinned to a fixed height with an inner scrollbar. A report with 8 reporters used to be a 420px box scrolling internally inside a half-width column. The activity feed, roster, and sessions grids (`.grid3`) are untouched.

**IP block audit entries now carry the target name.** For an offline target there is no live socket to read a username from, so it logged `user:?`. That was tolerable when the report card survived the action; now that the audit line is the only lasting record, it needs the name.

## Verification

Ran against a sandboxed server (scratch `DATA_DIR`, throwaway dev key) seeded with two reported users, one with 8 reporters:

- Warn on the 8-reporter card removed it immediately, count 2 -> 1, and the warning was queued for the offline target.
- IP block 7d on the second removed it, count 1 -> 0, Ban list 0 -> 1 with the countdown.
- Both survived a Refresh; `reports.json` on disk went to `{}`, in the original format.
- Audit log retained both actions, the block now reading `user:OtherPest(...)` rather than `user:?`.
- Layout measured in-page: one full-width column, cards at their natural 915px / 416px, zero clipped pixels, no inner scrollers, no horizontal page scroll. Appeals card 295px with the full appeal text visible.
- No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Reports no longer display handled or resolved status indicators.
  * Report counts and summaries now include all reports consistently.
  * Moderation actions now clear the relevant reports and refresh dashboards immediately.
  * Dashboard layouts are more flexible, with naturally sized cards and improved scrolling behavior.
  * IP-block activity logs now show the target’s name when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->